### PR TITLE
Ubuntu 16.04 で send コマンドが動くように修正

### DIFF
--- a/lib/device/library/linux.rb
+++ b/lib/device/library/linux.rb
@@ -2,7 +2,7 @@
 #
 # Copyright 2013 whiteleaf. All rights reserved.
 #
-require 'etc'
+require "etc"
 
 module Device::Library
   module Linux

--- a/lib/device/library/linux.rb
+++ b/lib/device/library/linux.rb
@@ -2,11 +2,14 @@
 #
 # Copyright 2013 whiteleaf. All rights reserved.
 #
+require 'etc'
 
 module Device::Library
   module Linux
+    @@mount_roots = %w(/media /mnt)
+    @@mount_roots << "/media/" + (Etc.getlogin || Etc.getpwuid.name)
     def get_device_root_dir(volume_name)
-      %w(/media /mnt).each do |mount_root|
+      @@mount_roots.each do |mount_root|
         path = File.join(mount_root, volume_name)
         if File.directory?(path)
           return path


### PR DESCRIPTION
Ubuntu 16.04 では Kindle のマウントポイントの場所が `/media/OSユーザー名/Kindle` 
となっています。一方、send コマンドが調べるマウントポイントは `/media/Kindle`
と `/mnt/Kindle` のみでした。
そこで、 `/media/OSユーザー名/Kindle` も調べるように修正しました。