### PR TITLE
Ubuntu 以外の udisks2 を使っている Linux でも send コマンドが動くように修正

### DIFF
--- a/lib/device/library/linux.rb
+++ b/lib/device/library/linux.rb
@@ -6,7 +6,7 @@ require "etc"
 
 module Device::Library
   module Linux
-    username = (Etc.getlogin || Etc.getpwuid.name)
+    username = Etc.getpwuid(Process.euid).name
     @@mount_roots = %w(/media /mnt)
     @@mount_roots << "/run/media/" + username # udisks2 による自動マウント(デフォルトの場所)
     @@mount_roots << "/media/" + username # udisks2 による自動マウント(Ubuntuの場合)

--- a/lib/device/library/linux.rb
+++ b/lib/device/library/linux.rb
@@ -6,8 +6,10 @@ require "etc"
 
 module Device::Library
   module Linux
+    username = (Etc.getlogin || Etc.getpwuid.name)
     @@mount_roots = %w(/media /mnt)
-    @@mount_roots << "/media/" + (Etc.getlogin || Etc.getpwuid.name)
+    @@mount_roots << "/run/media/" + username # udisks2 による自動マウント(デフォルトの場所)
+    @@mount_roots << "/media/" + username # udisks2 による自動マウント(Ubuntuの場合)
     def get_device_root_dir(volume_name)
       @@mount_roots.each do |mount_root|
         path = File.join(mount_root, volume_name)


### PR DESCRIPTION
Ubuntu 以外の udisks2 を使っている Linux は `/run/media/ユーザー名/Kindle` に
Kindle をマウントするようなので、 `/run/media/ユーザー名` も見るようにしました。

udisks2 はデフォルトでは `/run/media/ユーザー名` を使い、
Ubuntu はカスタマイズして `/media/ユーザー名` にしているようです。
