### PR TITLE
128.0.0.0 へのルーティングがないと narou web が起動しない問題の修正

### DIFF
--- a/lib/web/appserver.rb
+++ b/lib/web/appserver.rb
@@ -199,10 +199,16 @@ class Narou::AppServer < Sinatra::Base
   def self.my_ipaddress
     @@__ipaddress ||= -> {
       udp = UDPSocket.new
-      udp.connect("128.0.0.0", 7)
-      adrs = Socket.unpack_sockaddr_in(udp.getsockname)[1]
-      udp.close
-      adrs
+      begin
+        # 128.0.0.0 への送信に使用されるNICのアドレスを取得
+        udp.connect("128.0.0.0", 7)
+        Socket.unpack_sockaddr_in(udp.getsockname)[1]
+      rescue Errno::ENETUNREACH
+        # 128.0.0.0 へのルーティングがないとき
+        "127.0.0.1"
+      ensure
+        udp.close
+      end
     }.call
   end
 


### PR DESCRIPTION
インターネットへ繋いでない状態で `narou web` を実行すると以下のように失敗しました。
```shell
$ narou web -n
/home/kubo/local/ruby64-2.2.2/lib/ruby/gems/2.2.0/gems/narou-2.9.5/lib/web/appserver.rb:193:in `connect': Network is unreachable - connect(2) for "128.0.0.0" port 7 (Errno::ENETUNREACH)
```

IPアドレスの割り当てられているNICはいくつもあるのですが、以下のように default route が
設定されてないため 128.0.0.0 への送信に使用できる NIC が見付からず、 `Errno::ENETUNREACH`
例外があがります。
```shell
$ route -n
カーネルIP経路テーブル
受信先サイト    ゲートウェイ    ネットマスク   フラグ Metric Ref 使用数 インタフェース
10.0.3.0        0.0.0.0         255.255.255.0   U     0      0        0 lxcbr0
169.254.0.0     0.0.0.0         255.255.0.0     U     1000   0        0 enp0s31f6
172.16.42.0     0.0.0.0         255.255.255.0   U     0      0        0 vmnet8
172.16.78.0     0.0.0.0         255.255.255.0   U     0      0        0 vmnet1
192.168.0.0     0.0.0.0         255.255.255.0   U     0      0        0 enp0s31f6
```

`Errno::ENETUNREACH` 例外があがったとき適当な NIC のアドレスを取得する方法もありますが、
単純に `127.0.0.1` を自分のＩＰアドレスとするようにしました。
