### PR TITLE
fix: narou initを実行すると落ちる

### DIFF
--- a/lib/narou.rb
+++ b/lib/narou.rb
@@ -92,7 +92,7 @@ module Narou
   def init
     return nil if already_init?
     FileUtils.mkdir(LOCAL_SETTING_DIR_NAME)
-    puts "#{LOCAL_SETTING_DIR}/ を作成しました"
+    puts "#{LOCAL_SETTING_DIR_NAME}/ を作成しました"
     Database.init
   end
 


### PR DESCRIPTION
3.0.1でnarou.rbを初期設定しようとすると以下のエラーが出て終了しました。
> $ narou init
> /var/lib/gems/2.3.0/gems/narou-3.0.1/lib/narou.rb:95:in `init': uninitialized constant #<Class:Narou>::LOCAL_SETTING_DIR (NameError)
>   エラーが発生したため終了しました。
>   詳細なエラーは --backtrace オプションを付けて再度実行して下さい。

定数名を修正したところ、初期設定できるようになりました。