### PR TITLE
fix convert numbers

### DIFF
--- a/lib/converterbase.rb
+++ b/lib/converterbase.rb
@@ -94,7 +94,7 @@ class ConverterBase
     data.gsub!(/([\d０-９#{KANJI_NUM}]+?)[\.．]([\d０-９#{KANJI_NUM}]+?)/) do |match|
       integer = $1
       decimal = $2
-      if [/\d/, /[０-９]/, /[#{KANJI_NUM}]/].any? {|r| integer[-1] =~ r && decimal[0] =~ r }
+      if [/\d/, /[０-９]/, /[#{KANJI_NUM}]/].any? { |r| integer[-1] =~ r && decimal[0] =~ r }
         "#{integer}・#{decimal}"
       else
         match

--- a/lib/converterbase.rb
+++ b/lib/converterbase.rb
@@ -91,7 +91,15 @@ class ConverterBase
   #
   def convert_numbers(data)
     # 小数点を・に
-    data.gsub!(/([\d０-９#{KANJI_NUM}]+?)[\.．]([\d０-９#{KANJI_NUM}]+?)/, "\\1・\\2")
+    data.gsub!(/([\d０-９#{KANJI_NUM}]+?)[\.．]([\d０-９#{KANJI_NUM}]+?)/) do |match|
+      integer = $1
+      decimal = $2
+      if integer[-1] =~ /\d/ && decimal[0] =~ /\d/ || integer[-1] =~ /[０-９]/ && decimal[0] =~ /[０-９]/ || integer[-1] =~ /[#{KANJI_NUM}]/ && decimal[0] =~ /[#{KANJI_NUM}]/
+        "#{integer}・#{decimal}"
+      else
+        match
+      end
+    end
     if @setting.enable_convert_num_to_kanji &&
        @text_type != "subtitle" && @text_type != "chapter" && @text_type != "story"
       num_to_kanji(data)

--- a/lib/converterbase.rb
+++ b/lib/converterbase.rb
@@ -94,7 +94,7 @@ class ConverterBase
     data.gsub!(/([\d０-９#{KANJI_NUM}]+?)[\.．]([\d０-９#{KANJI_NUM}]+?)/) do |match|
       integer = $1
       decimal = $2
-      if integer[-1] =~ /\d/ && decimal[0] =~ /\d/ || integer[-1] =~ /[０-９]/ && decimal[0] =~ /[０-９]/ || integer[-1] =~ /[#{KANJI_NUM}]/ && decimal[0] =~ /[#{KANJI_NUM}]/
+      if [/\d/, /[０-９]/, /[#{KANJI_NUM}]/].any? {|r| integer[-1] =~ r && decimal[0] =~ r }
         "#{integer}・#{decimal}"
       else
         match


### PR DESCRIPTION
「`.`」の前後の数字の種類をチェックして、同じ種類の時のみ小数とみなすようにしました。
以下のようなordered listが小数と誤認識されるのを回避できるようになるはずです。
```
1.一石二鳥
```
