### PR TITLE
Fix problems introduced #167

### DIFF
--- a/lib/command/init.rb
+++ b/lib/command/init.rb
@@ -84,7 +84,7 @@ module Command
         path = check_aozoraepub3_path(@aozora_dirname)
         print "\n<bold><green>指定されたフォルダにAozoraEpub3がありません。</green></bold>\n".termcolor unless path
       end
-      aozora_path = (path or ask_aozoraepub3_path)
+      aozora_path = path || ask_aozoraepub3_path
       unless aozora_path
         puts "設定をスキップしました。あとで " + "<bold><yellow>narou init</yellow></bold>".termcolor + " で再度設定出来ます"
         return

--- a/lib/command/init.rb
+++ b/lib/command/init.rb
@@ -82,7 +82,7 @@ module Command
       end
       if @aozora_dirname
         path = check_aozoraepub3_path(@aozora_dirname)
-        print "\n<bold><green>指定されたフォルダにAozoraEpub3がありません。</green></bold>\n".termcolor if !path
+        print "\n<bold><green>指定されたフォルダにAozoraEpub3がありません。</green></bold>\n".termcolor unless path
       end
       aozora_path = (path or ask_aozoraepub3_path)
       unless aozora_path
@@ -142,19 +142,18 @@ module Command
       nil
     end
 
-    def check_aozoraepub3_path (input)
+    def check_aozoraepub3_path(input)
       if Helper.os_windows?
         input.force_encoding(Encoding::Windows_31J).encode!(Encoding::UTF_8)
       end
-      input = input.gsub(/"/, "")
+      input.delete!("\"")
       path = File.expand_path(input)
-      case
-      when input == ":keep"
+      if input == ":keep"
         aozora_dir = @global_setting["aozoraepub3dir"]
         if aozora_dir && Narou.aozoraepub3_directory?(aozora_dir)
           return aozora_dir
         end
-      when Narou.aozoraepub3_directory?(path)
+      elsif Narou.aozoraepub3_directory?(path)
         return path
       end
       nil


### PR DESCRIPTION
https://github.com/whiteleaf7/narou/pull/167#issuecomment-299682953 で指摘された問題と、別途発見した問題を修正しました。修正内容は以下の通りです。すみませんが、確認の上、マージをお願いします。

- ask_aozoraepub3_path関数の戻り値を使っていませんでした。orと=の優先度を間違えていました
- `narou init -p :keep`が動作していない問題を解決しました。この後の処理で`:keep`を確認していると勘違いしていました
- ディレクトリチェックしていない問題。これも`:keep`と同様に勘違いしていました
- グローバル設定がないまったくの初回に:keep の場合はこんな感じでしょうか
```
$ narou init -p :keep
------------------------------
AozoraEpub3の設定を行います
                            !!!WARNING!!!                             
AozoraEpub3の構成ファイルを書き換えます。narouコマンド用に別途新規インストールしておくことをオススメします

指定されたフォルダにAozoraEpub3がありません。

AozoraEpub3のあるフォルダを入力して下さい:
(未入力でスキップ)
>:keep

入力されたフォルダにAozoraEpub3がありません。もう一度入力して下さい:
>
設定をスキップしました。あとで narou init で再度設定出来ます
初期化が完了しました！
現在のフォルダ下で各種コマンドが使用出来るようになりました。
まずは narou help で簡単な説明を御覧ください。
```
