### PR TITLE
setting.iniで色々指定できるように

### DIFF
--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -352,8 +352,8 @@ class NovelConverter
   def initialize(setting, output_filename = nil, display_inspector = false, output_text_dir = nil)
     @setting = setting
     @novel_id = setting.id
-    @novel_author = setting.author
-    @novel_title = setting.title
+    @novel_author = setting.include?("novel_author") ? setting["novel_author"] : setting.author
+    @novel_title = setting.include?("novel_title") ? setting["novel_title"] : setting.title
     @output_filename = (output_filename || setting.output_filename)
     @inspector = Inspector.new(@setting)
     @illustration = Illustration.new(@setting, @inspector)
@@ -427,6 +427,8 @@ class NovelConverter
     cover_chuki = create_cover_chuki
     device = Narou.get_device
     setting = @setting
+    toc["title"] = setting["novel_title"] if setting.include?("novel_title")
+    toc["author"] = setting["novel_author"] if setting.include?("novel_author")
     processed_title = decorate_title(toc["title"])
     tempalte_name = (device && device.ibunko? ? NOVEL_TEXT_TEMPLATE_NAME_FOR_IBUNKO : NOVEL_TEXT_TEMPLATE_NAME)
     Template.get(tempalte_name, binding, 1.1)

--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -354,7 +354,7 @@ class NovelConverter
     @novel_id = setting.id
     @novel_author = setting.author
     @novel_title = setting.title
-    @output_filename = output_filename
+    @output_filename = (output_filename || setting.output_filename)
     @inspector = Inspector.new(@setting)
     @illustration = Illustration.new(@setting, @inspector)
     @display_inspector = display_inspector

--- a/lib/novelsetting.rb
+++ b/lib/novelsetting.rb
@@ -193,6 +193,10 @@ class NovelSetting
     @settings[name] = value
   end
 
+  def output_filename
+    @settings.fetch("output_filename", nil)
+  end
+
   #
   # replace.txt による置換定義を読み込む
   #

--- a/lib/novelsetting.rb
+++ b/lib/novelsetting.rb
@@ -197,6 +197,10 @@ class NovelSetting
     @settings.fetch("output_filename", nil)
   end
 
+  def include?(key)
+    @settings.include?(key)
+  end
+
   #
   # replace.txt による置換定義を読み込む
   #


### PR DESCRIPTION
[銀河連合日本](http://ncode.syosetu.com/n5084bv/)のファイル名が
```
[_本保羽] 銀河連合日本.txt
```
となるのが悲しい感じで、update コマンドには `-o` オプションもないので、`setting.ini` で指定できるようにしてみました。

ついでにタイトルや著者名に手を入れる手段が見当たらなかったので、こちらも指定できるようにしてみました。
例えば、[スライムなダンジョンで天下をとろうと思う（再掲載）](http://ncode.syosetu.com/n3782bu/)の「（再掲載）」の部分はいらないので。