### PR TITLE
WEB UIサーバにDigest認証する機能を追加

### DIFF
--- a/lib/command/setting.rb
+++ b/lib/command/setting.rb
@@ -524,7 +524,7 @@ module Command
           tab: :global
         },
         "server-digest-auth.password" => {
-          type: :string, help: "WEBサーバのDigest認証のパスワード",
+          type: :string, help: "WEBサーバのDigest認証のパスワード。hashed-passwordも設定した場合はそちらが優先される",
           tab: :global
         },
         "server-digest-auth.hashed-password" => {

--- a/lib/command/setting.rb
+++ b/lib/command/setting.rb
@@ -515,6 +515,24 @@ module Command
           invisible: true,
           tab: :global
         },
+        "server-digest-auth.use" => {
+          type: :boolean, help: "WEBサーバでDigest認証を使用するかどうか",
+          tab: :global
+        },
+        "server-digest-auth.user" => {
+          type: :string, help: "WEBサーバでDigest認証をするユーザ名",
+          tab: :global
+        },
+        "server-digest-auth.password" => {
+          type: :string, help: "WEBサーバのDigest認証のパスワード",
+          tab: :global
+        },
+        "server-digest-auth.hashed-password" => {
+          type: :string,
+          help: "WEBサーバのDigest認証のパスワードを、Realmを\"narou.rb\"としてハッシュにしたもの。下記のようなコマンドで生成できる\n" \
+                "$ ruby -r 'digest/md5' -e 'puts Digest::MD5.hexdigest \"\#{$*[0]}:narou.rb:\#{$*[1]}\"' user password",
+          tab: :global
+        },
         "server-ws-add-accepted-domains" => {
           type: :string, help: "PushServer の accepted_domains に追加するホストのリスト（カンマ区切り）",
           invisible: true,

--- a/lib/web/appserver.rb
+++ b/lib/web/appserver.rb
@@ -278,9 +278,9 @@ class Narou::AppServer < Sinatra::Base
     user = setting["server-digest-auth.user"]
     hashed = !!setting["server-digest-auth.hashed-password"]
     passwd = hashed ? setting["server-digest-auth.hashed-password"] : setting["server-digest-auth.password"]
-    
+
     self.class.class_exec do
-      use Rack::Auth::Digest::MD5, {realm: 'narou.rb', opaque:'', passwords_hashed: hashed} do |username|
+      use Rack::Auth::Digest::MD5, { realm: "narou.rb", opaque: "", passwords_hashed: hashed } do |username|
         passwd if username == user
       end
     end

--- a/lib/web/appserver.rb
+++ b/lib/web/appserver.rb
@@ -231,6 +231,7 @@ class Narou::AppServer < Sinatra::Base
     puts_hello_messages
     start_device_ejectable_event
     fill_general_all_no_in_database
+    setup_server_authentication
   end
 
   def puts_hello_messages
@@ -266,6 +267,23 @@ class Narou::AppServer < Sinatra::Base
       modified = true
     end
     Database.instance.save_database if modified
+  end
+
+  # サーバーの認証の設定
+  # とりあえずDigest認証のみ
+  def setup_server_authentication
+    setting = Inventory.load("global_setting", :global)
+    return unless setting["server-digest-auth.use"]
+
+    user = setting["server-digest-auth.user"]
+    hashed = !!setting["server-digest-auth.hashed-password"]
+    passwd = hashed ? setting["server-digest-auth.hashed-password"] : setting["server-digest-auth.password"]
+    
+    self.class.class_exec do
+      use Rack::Auth::Digest::MD5, {realm: 'narou.rb', opaque:'', passwords_hashed: hashed} do |username|
+        passwd if username == user
+      end
+    end
   end
 
   # ===================================================================

--- a/lib/web/settingmessages.rb
+++ b/lib/web/settingmessages.rb
@@ -19,7 +19,9 @@ module Narou
                       "<b>%OLD</b> : 古い方の差分用ファイルパス",
     "no-color" => "コンソールのカラー表示を無効にする\n※要WEB UIサーバ再起動",
     "economy" => "容量節約に関する設定",
-    "send.without-freeze" => "一括送信時に凍結された小説は対象外にする。（個別送信時は凍結済みでも送信可能）"
+    "send.without-freeze" => "一括送信時に凍結された小説は対象外にする。（個別送信時は凍結済みでも送信可能）",
+    "server-digest-auth.use" => "WEBサーバでDigest認証を使用するかどうか\n※要WEB UIサーバ再起動",
+    "server-digest-auth.hashed-password" => "WEBサーバのDigest認証のパスワードを、Realmを\"narou.rb\"としてハッシュにしたもの。\nhttps://tgws.plus/app/digest/ などで生成できる",
   }
 end
 


### PR DESCRIPTION
VPSとかに置いてクラウド的に使いたかったので、Digest認証でセキュリティ向上した気分にしました。

ユーザー、パスワードの設定方法に悩みましたが、とりあえず愚直にglobal_setting.yamlに書くようにしました(パスワードのハッシュも)