### PR TITLE
WEB UIで出力ファイル名・タイトル・著者名を指定できるように

### DIFF
--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -352,9 +352,9 @@ class NovelConverter
   def initialize(setting, output_filename = nil, display_inspector = false, output_text_dir = nil)
     @setting = setting
     @novel_id = setting.id
-    @novel_author = setting.author
-    @novel_title = setting.title
-    @output_filename = output_filename
+    @novel_author = setting.novel_author.empty? ? setting.author : setting.novel_author
+    @novel_title = setting.novel_title.empty? ? setting.title : setting.novel_title
+    @output_filename = setting.output_filename.empty? ? output_filename : setting.output_filename
     @inspector = Inspector.new(@setting)
     @illustration = Illustration.new(@setting, @inspector)
     @display_inspector = display_inspector
@@ -427,6 +427,8 @@ class NovelConverter
     cover_chuki = create_cover_chuki
     device = Narou.get_device
     setting = @setting
+    toc["title"] = setting.novel_title unless setting.novel_title.empty?
+    toc["author"] = setting.novel_author unless setting.novel_author.empty?
     processed_title = decorate_title(toc["title"])
     tempalte_name = (device && device.ibunko? ? NOVEL_TEXT_TEMPLATE_NAME_FOR_IBUNKO : NOVEL_TEXT_TEMPLATE_NAME)
     Template.get(tempalte_name, binding, 1.1)

--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -354,7 +354,7 @@ class NovelConverter
     @novel_id = setting.id
     @novel_author = setting.author
     @novel_title = setting.title
-    @output_filename = (output_filename || setting.output_filename)
+    @output_filename = output_filename
     @inspector = Inspector.new(@setting)
     @illustration = Illustration.new(@setting, @inspector)
     @display_inspector = display_inspector

--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -352,8 +352,8 @@ class NovelConverter
   def initialize(setting, output_filename = nil, display_inspector = false, output_text_dir = nil)
     @setting = setting
     @novel_id = setting.id
-    @novel_author = setting.include?("novel_author") ? setting["novel_author"] : setting.author
-    @novel_title = setting.include?("novel_title") ? setting["novel_title"] : setting.title
+    @novel_author = setting.author
+    @novel_title = setting.title
     @output_filename = (output_filename || setting.output_filename)
     @inspector = Inspector.new(@setting)
     @illustration = Illustration.new(@setting, @inspector)
@@ -427,8 +427,6 @@ class NovelConverter
     cover_chuki = create_cover_chuki
     device = Narou.get_device
     setting = @setting
-    toc["title"] = setting["novel_title"] if setting.include?("novel_title")
-    toc["author"] = setting["novel_author"] if setting.include?("novel_author")
     processed_title = decorate_title(toc["title"])
     tempalte_name = (device && device.ibunko? ? NOVEL_TEXT_TEMPLATE_NAME_FOR_IBUNKO : NOVEL_TEXT_TEMPLATE_NAME)
     Template.get(tempalte_name, binding, 1.1)

--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -354,7 +354,8 @@ class NovelConverter
     @novel_id = setting.id
     @novel_author = setting.novel_author.empty? ? setting.author : setting.novel_author
     @novel_title = setting.novel_title.empty? ? setting.title : setting.novel_title
-    @output_filename = setting.output_filename.empty? ? output_filename : setting.output_filename
+    @output_filename = (output_filename || setting.output_filename)
+    @output_filename = nil if @output_filename.empty?
     @inspector = Inspector.new(@setting)
     @illustration = Illustration.new(@setting, @inspector)
     @display_inspector = display_inspector

--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -572,9 +572,9 @@ class NovelConverter
       end
       filename = Narou.create_novel_filename(info)
       output_path = File.join(@setting.archive_path, filename)
-      if output_path !~ /\.\w+$/
-        output_path += ".txt"
-      end
+    end
+    if output_path !~ /\.\w+$/
+      output_path += ".txt"
     end
     output_path
   end

--- a/lib/novelsetting.rb
+++ b/lib/novelsetting.rb
@@ -193,10 +193,6 @@ class NovelSetting
     @settings[name] = value
   end
 
-  def output_filename
-    @settings.fetch("output_filename", nil)
-  end
-
   #
   # replace.txt による置換定義を読み込む
   #

--- a/lib/novelsetting.rb
+++ b/lib/novelsetting.rb
@@ -197,10 +197,6 @@ class NovelSetting
     @settings.fetch("output_filename", nil)
   end
 
-  def include?(key)
-    @settings.include?(key)
-  end
-
   #
   # replace.txt による置換定義を読み込む
   #

--- a/lib/novelsetting.rb
+++ b/lib/novelsetting.rb
@@ -471,6 +471,25 @@ $ntag 小説のタグをカンマ区切りにしたもの
       select_keys: %w(css simple plain),
       select_summaries: %w(CSSで装飾 シンプルに段落 装飾しない)
     },
+    {
+      name: "output_filename",
+      type: :string,
+      value: "",
+      help: "出力ファイル名を指定を指定する。" \
+            "（拡張子の「.txt」まで指定すること）"
+    },
+    {
+      name: "novel_author",
+      type: :string,
+      value: "",
+      help: "小説の著者名を指定する。何も指定しない場合は元々の著者名"
+    },
+    {
+      name: "novel_title",
+      type: :string,
+      value: "",
+      help: "小説のタイトルを指定する。何も指定しない場合は元々のタイトル"
+    },
   ]
 
   ORIGINAL_SETTINGS_KEY_INDEXES = {}.tap { |hash|

--- a/lib/novelsetting.rb
+++ b/lib/novelsetting.rb
@@ -472,23 +472,22 @@ $ntag 小説のタグをカンマ区切りにしたもの
       select_summaries: %w(CSSで装飾 シンプルに段落 装飾しない)
     },
     {
-      name: "output_filename",
-      type: :string,
-      value: "",
-      help: "出力ファイル名を指定を指定する。" \
-            "（拡張子の「.txt」まで指定すること）"
-    },
-    {
       name: "novel_author",
       type: :string,
       value: "",
-      help: "小説の著者名を指定する。何も指定しない場合は元々の著者名"
+      help: "小説の著者名を変更する。作品内著者名及び出力ファイル名に影響する"
     },
     {
       name: "novel_title",
       type: :string,
       value: "",
-      help: "小説のタイトルを指定する。何も指定しない場合は元々のタイトル"
+      help: "小説のタイトルを変更する。作品内タイトル及び出力ファイル名に影響する"
+    },
+    {
+      name: "output_filename",
+      type: :string,
+      value: "",
+      help: "出力ファイル名を任意の文字列に変更する。convert.filename-to-ncode の影響を受けない"
     },
   ]
 


### PR DESCRIPTION
#179 で指摘を受けた件を修正し、WEB UIで指定できるようにしました。

`ORIGINAL_SETTINGS` に追加すると自動的にアクセサが定義されるので、それを利用する実装に変更しました。