### PR TITLE
inspect関連のバグ修正

### DIFF
--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -718,9 +718,10 @@ class NovelConverter
 
   def inspect_novel(array_of_text)
     if @setting.enable_inspect
-      text = array_of_text.flatten
-      @inspector.inspect_end_touten_conditions(text)   # 行末読点の現在状況を調査する
-      @inspector.countup_return_in_brackets(text)      # カギ括弧内の改行状況を調査する
+      array_of_text.each do |text|
+        @inspector.inspect_end_touten_conditions(text)   # 行末読点の現在状況を調査する
+        @inspector.countup_return_in_brackets(text)      # カギ括弧内の改行状況を調査する
+      end
     end
 
     if !@display_inspector

--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -391,10 +391,10 @@ class NovelConverter
       array_of_converted_text = convert_main_for_novel
       update_latest_convert_novel
     end
-    inspect_novel(array_of_converted_text)
 
     array_of_output_path = []
     array_of_converted_text.each_with_index do |converted_text, i|
+      inspect_novel(converted_text)
       output_path = create_output_path(text, converted_text, i + 1)
       File.write(output_path, converted_text)
       array_of_output_path.push(output_path)
@@ -716,9 +716,8 @@ class NovelConverter
     { "title" => title, "author" => author }
   end
 
-  def inspect_novel(array_of_text)
+  def inspect_novel(text)
     if @setting.enable_inspect
-      text = array_of_text.flatten
       @inspector.inspect_end_touten_conditions(text)   # 行末読点の現在状況を調査する
       @inspector.countup_return_in_brackets(text)      # カギ括弧内の改行状況を調査する
     end

--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -391,10 +391,10 @@ class NovelConverter
       array_of_converted_text = convert_main_for_novel
       update_latest_convert_novel
     end
+    inspect_novel(array_of_converted_text)
 
     array_of_output_path = []
     array_of_converted_text.each_with_index do |converted_text, i|
-      inspect_novel(converted_text)
       output_path = create_output_path(text, converted_text, i + 1)
       File.write(output_path, converted_text)
       array_of_output_path.push(output_path)
@@ -716,8 +716,9 @@ class NovelConverter
     { "title" => title, "author" => author }
   end
 
-  def inspect_novel(text)
+  def inspect_novel(array_of_text)
     if @setting.enable_inspect
+      text = array_of_text.flatten
       @inspector.inspect_end_touten_conditions(text)   # 行末読点の現在状況を調査する
       @inspector.countup_return_in_brackets(text)      # カギ括弧内の改行状況を調査する
     end


### PR DESCRIPTION
#232 の修正です。以前の修正に間違いがありました。

```
$ narou s force.enable_inspect=true
$ narou c n7975cr
ID:46　蜘蛛ですが、なにか？ の変換を開始
小説状態の調査結果を 調査ログ.txt に出力しました（エラー：6件、警告：0件、INFO：1件）
縦書用の変換が終了しました
AozoraEpub3でEPUBに変換しています.....変換しました
kindlegen実行中...........................変換しました
kindlestrip実行中
[馬場翁] 蜘蛛ですが、なにか？.mobi を出力しました
MOBIファイルを出力しました
```