### PR TITLE
avoid encoding when arg is an Integer instance

### DIFF
--- a/lib/commandline.rb
+++ b/lib/commandline.rb
@@ -51,7 +51,7 @@ module CommandLine
   def argv_for_windows(argv)
     return unless Helper.os_windows?
     argv.map! do |arg|
-      arg&.encode(Encoding::UTF_8)
+      arg.class == Integer ? arg : arg&.encode(Encoding::UTF_8)
     end
   end
 


### PR DESCRIPTION
RSpec 実行時の error を回避。