### PR TITLE
add development dependencies to narou.gemspec

### DIFF
--- a/narou.gemspec
+++ b/narou.gemspec
@@ -65,5 +65,9 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'open_uri_redirections', '~> 0.2', '>= 0.2.1'
   gem.add_runtime_dependency 'activesupport', '~> 5.2'
   gem.add_runtime_dependency 'unicode-display_width', '~> 1.4'
+  gem.add_development_dependency 'pry'
+  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rubocop'
+  gem.add_development_dependency 'simplecov'
+  gem.add_development_dependency 'timecop'
 end
-


### PR DESCRIPTION
それぞれの開発時用 gems の版は、よく分からないので指定していません。(この pull request を merge していただいた後に) 必要に応じて指定していただければと思いますが、とりあえず現状では版指定しなくても (現時点の最新版でも) 動作しているように見えます。