### PR TITLE
avoid last argument as keyword parameters

### DIFF
--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -464,7 +464,7 @@ module Helper
         fullpath = File.expand_path(path)
         cache_data = @@caches[fullpath]
         if Helper.file_latest?(fullpath) || !cache_data
-          body = File.read(fullpath, options)
+          body = File.read(fullpath, **options)
           @@caches[fullpath] = body
           return body
         else
@@ -493,7 +493,7 @@ module Helper
         key = generate_key(fullpath, block)
         cache = @@result_caches[key]
         if Helper.file_latest?(fullpath) || !cache
-          data = File.read(fullpath, options)
+          data = File.read(fullpath, **options)
           @@result_caches[key] = result = block.call(data)
           return result
         else


### PR DESCRIPTION
改変の参考記事:「[暗黙的にハッシュオブジェクトをキーワード引数に変換している場合](https://qiita.com/jnchito/items/c15ac23791e0320e0fc2#%E8%AA%AC%E6%98%8E%E3%81%9D%E3%81%AE1%E6%9A%97%E9%BB%99%E7%9A%84%E3%81%AB%E3%83%8F%E3%83%83%E3%82%B7%E3%83%A5%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%82%92%E3%82%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%89%E5%BC%95%E6%95%B0%E3%81%AB%E5%A4%89%E6%8F%9B%E3%81%97%E3%81%A6%E3%81%84%E3%82%8B%E5%A0%B4%E5%90%88)」