### PR TITLE
avoid nul-separated glob pattern

### DIFF
--- a/lib/sitesetting.rb
+++ b/lib/sitesetting.rb
@@ -24,7 +24,7 @@ class SiteSetting
       load_paths = [
         Narou.script_dir.join(NOVEL_SITE_SETTING_DIR, "*.yaml"),
         Narou.root_dir.join(NOVEL_SITE_SETTING_DIR, "*.yaml")
-      ].uniq.join("\0")
+      ].uniq
       Dir.glob(load_paths) do |path|
         setting = SiteSetting.load_file(path)
         name = setting["name"]


### PR DESCRIPTION
私の手元の Ruby 2.7 はこの改変でうまく動作しているように見えますが、他の環境は未検証です。