### PR TITLE
fill department names in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -137,7 +137,7 @@ Style/NegatedIf:
 Style/Not:
   Enabled: true
 
-PercentLiteralDelimiters:
+Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     "%":  "!!"
     "%i": "()"
@@ -158,7 +158,7 @@ Style/RedundantReturn:
 Style/RedundantSelf:
   Enabled: false
 
-SignalException:
+Style/SignalException:
   EnforcedStyle: only_raise
 
 Layout/SpaceAfterComma:
@@ -197,7 +197,7 @@ Style/TrivialAccessors:
 Style/UnlessElse:
   Enabled: true
 
-VariableName:
+Naming/VariableName:
   EnforcedStyle: snake_case
 
 Style/WordArray:


### PR DESCRIPTION
この修正をしないと、rubocop 実行時に大量の warning が出ます。([参考記事](https://stackoverflow.com/questions/58218587/how-to-disable-warning-no-department-given-for-cop-message-on-running-rubocop))