### PR TITLE
URI.regexp 書き直し

### DIFF
--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -89,7 +89,7 @@ class Downloader
   #
   def self.get_target_type(target)
     case target
-    when URI.regexp
+    when /^[Hh][Tt][Tt][Pp][Ss]?:\/\//
       :url
     when /^n\d+[a-z]+$/i
       target.downcase!


### PR DESCRIPTION
Ruby 2.2 の頃より [`URI.regexp` は obsolete](https://docs.ruby-lang.org/ja/2.2.0/class/URI.html#S_REGEXP) のようです。一応現状でも動きますが、いずれ単なる obsolete から error になるのではないかと思います。

とりあえず downloader.rb だけ書き直し、RSpec が all green になることを確認しました。他にも以下の2か所に残っています (手を付けていません)。

 * converterbase.rb(998):     `data.gsub!(URI.regexp(%w(http https))) do |match|`
 * illustration.rb(30):       `if url =~ URI.regexp`