### PR TITLE
URI.regexp → URI::DEFAULT_PARSER.make_regexp

### DIFF
--- a/lib/converterbase.rb
+++ b/lib/converterbase.rb
@@ -995,7 +995,7 @@ class ConverterBase
   # URL っぽい文字列を一旦別のIDに置き換えてあとで復元することで、変換処理の影響を受けさせない
   #
   def replace_url(data)
-    data.gsub!(URI.regexp(%w(http https))) do |match|
+    data.gsub!(URI::DEFAULT_PARSER.make_regexp(%w(http https))) do |match|
       @url_list << match
       "［＃ＵＲＬ＝#{@url_list.size - 1}］"
     end

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -89,7 +89,7 @@ class Downloader
   #
   def self.get_target_type(target)
     case target
-    when URI.regexp
+    when URI::DEFAULT_PARSER.make_regexp
       :url
     when /^n\d+[a-z]+$/i
       target.downcase!

--- a/lib/illustration.rb
+++ b/lib/illustration.rb
@@ -27,7 +27,7 @@ class Illustration
     source.gsub!(/［＃挿絵（(.+?)）入る］/) do |match|
       url = $1
       url = "https:#{url}" if url.start_with?("//")
-      if url =~ URI.regexp
+      if url =~ URI::DEFAULT_PARSER.make_regexp
         path = download_image(url)
         path ? block.call(make_illust_chuki(path)) : ""
       else


### PR DESCRIPTION
Rubocop における以下の説明に従って、手動で修正しました。(Rubocop の auto-correct を用いた自動修正は、まだ動作が怪しくて今回未使用です。)

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UriRegexp

一応、RSpec も全部通るように見えます (Windows 10)。