### PR TITLE
remove `Style/BracesAroundHashParameters` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,9 +56,6 @@ Style/AndOr:
 Style/BlockDelimiters:
   Enabled: false
 
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 Style/CollectionMethods:
   PreferredMethods:
     detect: "detect"


### PR DESCRIPTION
Ruby 2.7 から該当する括弧が意味を持つようになり、RuboCop 0.80.1 から削除されました。 

これに合わせ、こちらの .rubocop からも削除しました。(残ったままだと、RuboCop は error を出します。)