### PR TITLE
avoid dir error with Newer AozoraEpub3

### DIFF
--- a/lib/extension.rb
+++ b/lib/extension.rb
@@ -27,6 +27,7 @@ def File.write(path, string, *options, mode: nil)
   return super if mode
 
   dirpath = File.dirname(path)
+  FileUtils.makedirs(dirpath) unless Dir.exist?(dirpath)
   temp_path = File.join(dirpath, SecureRandom.hex(15))
   if File.extname(path) == ".yaml" && File.basename(dirpath) != Downloader::SECTION_SAVE_DIR_NAME
     backup = "#{path}.backup"


### PR DESCRIPTION
「[AozoraEpub3は公式版作者が失踪したので↓を使用](https://jbbs.shitaraba.net/bbs/read.cgi/computer/44668/1511245701/280)」という記述を見てその通りに作業し `narou init` したところ、以下が発生。対処のため、1行追加。

/xxx/narou-3.5.1/lib/extension.rb:30:in `mkdir': No such file or directory @ dir_s_mkdir - /xxx/AozoraEpub3/template/OPS/css_custom (Errno::ENOENT)