### PR TITLE
404の場合でもウェイトを挟む

### DIFF
--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -801,6 +801,7 @@ class Downloader
     raise if through_error   # エラー処理はしなくていいからそのまま例外を受け取りたい時用
     if e.message.include?("404")
       @stream.error "小説が削除されているか非公開な可能性があります"
+      sleep_for_download
       if database.novel_exists?(@id)
         Command::Tag.execute!(%W(#{@id} --add 404 --color white --no-overwrite-color), io: Narou::NullIO.new)
         Command::Freeze.execute!(@id, "--on")


### PR DESCRIPTION
手元にあるリストを入力し、連続でダウンロードを実行する際に、連続して削除された小説があった場合にウェイトが無いとアクセス制限がかかり、10分程度待った上で手動で再試行する必要がありました。

削除されていた場合にもウェイトを入れている場合は100件程度をまとめて入力した場合にもこの問題は発生しませんでした。