### PR TITLE
fix "duplicated range"

### DIFF
--- a/lib/command/tag.rb
+++ b/lib/command/tag.rb
@@ -12,7 +12,7 @@ module Command
   class Tag < CommandBase
     COLORS = %w(green yellow blue magenta cyan red white)
     # 禁止文字
-    BAN_CHAR = /[:;"'><$@&^\\\|%'\/`]/
+    BAN_CHAR = /[:;"'><$@&^\\\|%\/`]/
     # 禁止ワード
     BAN_WORD = %w(hotentry)
 

--- a/lib/converterbase.rb
+++ b/lib/converterbase.rb
@@ -15,7 +15,7 @@ require_relative "inspector"
 
 class ConverterBase
   KANJI_NUM = "〇一二三四五六七八九"
-  ENGLISH_SENTENCES_CHARACTERS = /[\w.,!?'" &:;_-]+/
+  ENGLISH_SENTENCES_CHARACTERS = /[\w.,!?'" &:;-]+/
   ENGLISH_SENTENCES_MIN_LENGTH = 8   # この文字数以上アルファベットが続くと半角のまま
 
   attr_reader :use_dakuten_font


### PR DESCRIPTION
通常の実行には問題ありませんが、-W2 を付けて実行すると警告が出るので、以下の点を修正しました。

* lib/command/tag.rb (15行目、`'` が2回出現しているため1つ削除)
* lib/converterbase.rb (18行目、[`_` は `\w` に含まれる](https://docs.ruby-lang.org/ja/latest/doc/spec=2fregexp.html#string)ため削除)

Ruby 3.1.2 上では RSpec を実行して `875 examples, 0 failures, 2 pending` でした。