### PR TITLE
Pagination support; 小説家になろう目次ページの分割への対応

### DIFF
--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -725,6 +725,7 @@ class Downloader
     toc_source = ""
     cookie = @setting["cookie"] || ""
     open_uri_options = make_open_uri_options("Cookie" => cookie, allow_redirections: :safe)
+    sleep_for_download
     begin
       URI.open(toc_url, open_uri_options) do |toc_fp|
         if toc_fp.base_uri.to_s != toc_url
@@ -833,7 +834,6 @@ class Downloader
       progressbar&.output(i + 1)
       subtitles.concat(get_subtitles(toc_source, old_toc))
       break unless @setting.multi_match(toc_source, "next_toc")
-      sleep_for_download
       # 得られたURLをセットしてページ内容を取得する
       @setting["toc_url"] = @setting["next_url"]
       toc_source = get_toc_source

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -11,6 +11,7 @@ require_relative "narou"
 require_relative "helper"
 require_relative "sitesetting"
 require_relative "template"
+require_relative "progressbar"
 require_relative "database"
 require_relative "inventory"
 require_relative "eventable"
@@ -783,20 +784,7 @@ class Downloader
     @setting["title"] = get_title
     if series_novel?
       # 連載小説
-      subtitles = []
-      toc_url = @setting["toc_url"]
-      source = toc_source
-      100.times do
-        subtitles.concat(get_subtitles(source, old_toc))
-        break unless @setting.multi_match(source, "next_toc")
-        sleep_for_download
-        @setting["toc_url"] = @setting["next_url"]
-        begin
-          source = get_toc_source
-        ensure
-          @setting["toc_url"] = toc_url
-        end
-      end
+      subtitles = get_subtitles_multipage(toc_source, old_toc)
     else
       # 短編小説
       subtitles = create_short_story_subtitles(info)
@@ -824,6 +812,41 @@ class Downloader
       @stream.error "何らかの理由により目次が取得できませんでした(#{e.message})"
     end
     false
+  end
+
+  def get_subtitles_multipage(toc_source, old_toc)
+    subtitles = []
+    # 元々のURLを保存する
+    toc_url_orig = @setting["toc_url"]
+    # 全ページ数を得る
+    @setting.multi_match(toc_source, "toc_page_max")
+    toc_page_max = @setting["toc_page_max"].to_i
+    # toc_page_maxが設定されていない、正規表現にマッチしない場合などでも最低限は1にする
+    toc_page_max = 1 unless toc_page_max > 0
+    # 5ページ以上でプログレスバーを表示する
+    progressbar =  nil
+    if toc_page_max >= 5
+      @stream.puts "#{@setting["title"]} の目次ページを取得中..."
+      progressbar = ProgressBar.new(toc_page_max, io: @stream)
+    end
+    ret = toc_page_max.times do |i|
+      progressbar&.output(i + 1)
+      subtitles.concat(get_subtitles(toc_source, old_toc))
+      break unless @setting.multi_match(toc_source, "next_toc")
+      sleep_for_download
+      # 得られたURLをセットしてページ内容を取得する
+      @setting["toc_url"] = @setting["next_url"]
+      toc_source = get_toc_source
+    end
+    progressbar&.clear
+    if ret
+      # 通常ならbreakでループを抜けるはず
+      # breakでループを抜けなかったら例外を出す
+      raise "目次ページが多すぎます"
+    end
+    subtitles
+  ensure
+    @setting["toc_url"] = toc_url_orig
   end
 
   def __search_index_in_subtitles(subtitles, index)

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -783,7 +783,20 @@ class Downloader
     @setting["title"] = get_title
     if series_novel?
       # 連載小説
-      subtitles = get_subtitles(toc_source, old_toc)
+      subtitles = []
+      toc_url = @setting["toc_url"]
+      source = toc_source
+      100.times do
+        subtitles.concat(get_subtitles(source, old_toc))
+        break unless @setting.multi_match(source, "next_toc")
+        sleep_for_download
+        @setting["toc_url"] = @setting["next_url"]
+        begin
+          source = get_toc_source
+        ensure
+          @setting["toc_url"] = toc_url
+        end
+      end
     else
       # 短編小説
       subtitles = create_short_story_subtitles(info)

--- a/webnovel/ncode.syosetu.com.yaml
+++ b/webnovel/ncode.syosetu.com.yaml
@@ -27,6 +27,8 @@ subtitles: |-
   </dl>
 next_toc: <a href="/(?<next_page>[^"]+)" class="novelview_pager-next">
 next_url: https://\\k<domain>/\\k<next_page>/
+# 最大のページ数を得る。固定の数字でも可。
+toc_page_max: <a href="/[^"]+p=(?<toc_page_max>\d+)" class="novelview_pager-last">
 
 # ------------------------------------------------------------
 # 本文取得設定

--- a/webnovel/ncode.syosetu.com.yaml
+++ b/webnovel/ncode.syosetu.com.yaml
@@ -25,6 +25,8 @@ subtitles: |-
   <dt class="long_update">
   (?<subdate>.+?)(?:<span title="(?<subupdate>.+?) 改稿">（<u>改</u>）</span>)?</dt>
   </dl>
+next_toc: <a href="/(?<next_page>[^"]+)" class="novelview_pager-next">
+next_url: https://\\k<domain>/\\k<next_page>/
 
 # ------------------------------------------------------------
 # 本文取得設定

--- a/webnovel/ncode.syosetu.com.yaml
+++ b/webnovel/ncode.syosetu.com.yaml
@@ -17,7 +17,7 @@ version: 2.0
 toc_url: https://\\k<domain>/\\k<ncode>/
 subtitles: |-
   (?:<div class="chapter_title">(?<chapter>.+?)</div>
-   
+  
   )?<dl class="novel_sublist2">
   <dd class="subtitle">
   <a href="(?<href>/.+?/(?<index>\d+?)/)">(?<subtitle>.+?)</a>

--- a/webnovel/ncode.syosetu.com.yaml
+++ b/webnovel/ncode.syosetu.com.yaml
@@ -26,7 +26,7 @@ subtitles: |-
   (?<subdate>.+?)(?:<span title="(?<subupdate>.+?) 改稿">（<u>改</u>）</span>)?</dt>
   </dl>
 next_toc: <a href="/(?<next_page>[^"]+)" class="novelview_pager-next">
-next_url: https://\\k<domain>/\\k<next_page>/
+next_url: https://\\k<domain>/\\k<next_page>
 # 最大のページ数を得る。固定の数字でも可。
 toc_page_max: <a href="/[^"]+p=(?<toc_page_max>\d+)" class="novelview_pager-last">
 

--- a/webnovel/novel18.syosetu.com.yaml
+++ b/webnovel/novel18.syosetu.com.yaml
@@ -31,7 +31,7 @@ subtitles: |-
   (?<subdate>.+?)(?:<span title="(?<subupdate>.+?) 改稿">（<u>改</u>）</span>)?</dt>
   </dl>
 next_toc: <a href="/(?<next_page>[^"]+)" class="novelview_pager-next">
-next_url: https://\\k<domain>/\\k<next_page>/
+next_url: https://\\k<domain>/\\k<next_page>
 # 最大のページ数を得る。固定の数字でも可。
 toc_page_max: <a href="/[^"]+p=(?<toc_page_max>\d+)" class="novelview_pager-last">
 

--- a/webnovel/novel18.syosetu.com.yaml
+++ b/webnovel/novel18.syosetu.com.yaml
@@ -32,6 +32,8 @@ subtitles: |-
   </dl>
 next_toc: <a href="/(?<next_page>[^"]+)" class="novelview_pager-next">
 next_url: https://\\k<domain>/\\k<next_page>/
+# 最大のページ数を得る。固定の数字でも可。
+toc_page_max: <a href="/[^"]+p=(?<toc_page_max>\d+)" class="novelview_pager-last">
 
 # ------------------------------------------------------------
 # 本文取得設定

--- a/webnovel/novel18.syosetu.com.yaml
+++ b/webnovel/novel18.syosetu.com.yaml
@@ -22,7 +22,7 @@ version: 2.0
 toc_url: https://\\k<domain>/\\k<ncode>/
 subtitles: |-
   (?:<div class="chapter_title">(?<chapter>.+?)</div>
-   
+  
   )?<dl class="novel_sublist2">
   <dd class="subtitle">
   <a href="(?<href>/.+?/(?<index>\d+?)/)">(?<subtitle>.+?)</a>

--- a/webnovel/novel18.syosetu.com.yaml
+++ b/webnovel/novel18.syosetu.com.yaml
@@ -30,6 +30,8 @@ subtitles: |-
   <dt class="long_update">
   (?<subdate>.+?)(?:<span title="(?<subupdate>.+?) 改稿">（<u>改</u>）</span>)?</dt>
   </dl>
+next_toc: <a href="/(?<next_page>[^"]+)" class="novelview_pager-next">
+next_url: https://\\k<domain>/\\k<next_page>/
 
 # ------------------------------------------------------------
 # 本文取得設定


### PR DESCRIPTION
小説家になろう目次ページの分割への対応
修正しました。
~~念のため無限ループ対策として最大100ページまでに制限してます。~~
プログレスバーの付加にあわせて全ページ数を取得するようにしました。
~~そこまで必要かわかりませんでしたが、念のため、`toc_url`は毎回ループ前の値に復帰しています。~~
別メソッド分離にあわせて、メソッド終了時に復帰するようにしました。