### PR TITLE
Fix a few bug

### DIFF
--- a/lib/command/diff.rb
+++ b/lib/command/diff.rb
@@ -250,7 +250,7 @@ module Command
         list: []
       }
       cache_list = get_sorted_cache_list(id)
-      return list if cache_list.empty?
+      return list if cache_list.blank?
       cache_list.each.with_index(1) do |cache_path, i|
         objects = []
         version_string = File.basename(cache_path)

--- a/lib/command/diff.rb
+++ b/lib/command/diff.rb
@@ -70,7 +70,7 @@ module Command
     # 引数の中の -数字 オプション(-n 数字の省略形)を -n 数字 に変換する
     def short_number_option_parse(argv)
       argv.map! { |arg|
-        if arg =~ /^-(\d+)$/
+        if arg.to_s =~ /^-(\d+)$/
           ["-n", $1.to_s]
         else
           arg

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -102,7 +102,7 @@ module Helper
   end
 
   def replace_filename_special_chars(str, invalid_replace = false)
-    result = str.tr("/:*?\"<>|.`", "／：＊？”〈〉｜．｀").gsub("\\", "￥").gsub("\t", "").gsub("\n", "")
+    result = str.tr("/:*?\"<>[]{}|.`", "／：＊？”〈〉［］｛｝｜．｀").gsub("\\", "￥").gsub("\t", "").gsub("\n", "")
     if Inventory.load("local_setting")["normalize-filename"]
       begin
         result.unicode_normalize!

--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -100,6 +100,7 @@ class NovelConverter
       if DAKUTEN_ERB[i]
         Helper.erb_copy(src, dst, binding)
       else
+        FileUtils.mkdir_p(File.dirname(dst))
         FileUtils.copy(src, dst)
       end
     end


### PR DESCRIPTION
いくつかまとめてプルリクします。

### fix: /api/diff_clean pass Integer and NoMethodError (ruby Feature #15231 : Remove `Object#=~`)
/api/diff_clean で`CommandLine.run!`に`Integer`が渡されているが、ruby3.2より`Object#=~`が削除されたため`Integer#=~`がNoMethodErrorとなる
いったんto_sでStringにして処理する

### fix: undefined method `empty?' for nil:NilClass
レアケースだが、小説の保存フォルダが消えている場合、`get_sorted_cache_list`がnilを返すためNoMethodErrorとなる
empty?ではなくactivesupportのblank?を使う

### fix: Downloader#get_cache_list return empty if dir includes glob wildcards char
小説タイトルにglobのワイルドカードである「[]{}」があるとdiffで`Dir.glob`が期待したリストを返さず、差分が表示されないなどの不具合が発生する

### fix: fail font copy if dir not exist
template/OPS/fontsが無い場合、フォントがコピーされないのでコピー前にディレクトリを作る
`FileUtils.mkdir_p`は存在を確認するので、事前にディレクトリの有無はチェックしない
