### PR TITLE
カクヨム対応関係

### DIFF
--- a/lib/sitesetting.rb
+++ b/lib/sitesetting.rb
@@ -6,6 +6,7 @@
 
 require "yaml"
 require_relative "narou/api"
+require_relative "sitesettinghandler"
 
 class SiteSetting
   NOVEL_SITE_SETTING_DIR = "webnovel/"
@@ -101,14 +102,18 @@ class SiteSetting
     keys.each do |key|
       setting_value = self[key] or next
       [*setting_value].each do |value|
-        match_data = source.match(/#{value}/m)
-        if match_data
-          @match_values[key] = value       # yamlのキーでもmatch_valuesに設定しておくが、
-          update_match_values(match_data)  # ←ここで同名のグループ名が定義されていたら上書きされるので注意
-                                           # 例えば、title: <title>(?<title>.+?)</title> と定義されていた場合、
-                                           # @match_values["title"] には (?<title>.+?) 部分の要素が反映される
-          break
-        end
+        handle = SiteSettingHandler.handler(self, value)
+        match_data = handle&.match(source) # ハンドルオブジェクトを得て、それにより処理する
+        next unless match_data
+        value = handle.value if handle.respond_to?(:value)
+                                         # rubocop:disable Layout/CommentIndentation
+                                         # 通常はこれまで通りだが、valueを変更することも可能にする
+        @match_values[key] = value       # yamlのキーでもmatch_valuesに設定しておくが、
+        update_match_values(match_data)  # ←ここで同名のグループ名が定義されていたら上書きされるので注意
+                                         # 例えば、title: <title>(?<title>.+?)</title> と定義されていた場合、
+                                         # @match_values["title"] には (?<title>.+?) 部分の要素が反映される
+                                         # rubocop:enable Layout/CommentIndentation
+        break
       end
     end
     match_data

--- a/lib/sitesettinghandler.rb
+++ b/lib/sitesettinghandler.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "weakref"
+require_relative "worker"
+
+class SiteSettingHandler
+  HANDLER_DIR = "handler"
+  HANDLER_EXT = ".rb"
+
+  @@klasses = {}
+
+  class << self
+    # @type : ハンドラのタイプ名
+    attr_reader :type
+
+    #
+    # ハンドラを登録する
+    #
+    # 継承したクラスで呼び出してハンドラを登録する
+    # 通常、ファイル名からタイプ名を作るが、引数で直接指定も出来る
+    # クラスを継承していない場合はクラスを指定して登録する
+    #
+    def add_handler(path_or_type: @@current_path, klass: self)
+      @type = File.basename(path_or_type, HANDLER_EXT)
+      @@klasses[@type] = klass
+    end
+
+    #
+    # ハンドラの呼び出し
+    #
+    # 引数から対応するハンドラを呼び出しインスタンスを作る
+    # 引数がこのクラスの派生オブジェクトならそのまま返す
+    # それ以外でもメソッドmatchを持つならそのまま返す
+    # それ以外なら正規表現であるので正規表現ハンドラにして返す
+    #
+    def handler(parent, value)
+      case value
+      when Array
+        # key:
+        #   type: value
+        _make_handler(parent, *value)
+      when Hash
+        # key:
+        #   - type: value
+        _make_handler(parent, *value.flatten)
+      when String
+        # key:
+        #   value
+        /#{value}/m
+      when self
+        # 派生オブジェクトならそのまま返す
+        value
+      else
+        if value.respond_to?(:match)
+          # matchメソッドを持つオブジェクトならそのまま返す
+          value
+        else
+          # その他であれば正規表現として生成
+          /#{value}/m
+        end
+      end
+    end
+
+    def _make_handler(parent, type, value)
+      # typeが未登録の場合、例外が発生する
+      klass = @@klasses.fetch(type)
+      klass.make(value, WeakRef.new(parent))
+    end
+
+    # makeを再定義すれば別のインスタンスを返すことも可能
+    alias make new
+
+  end
+
+  def initialize(value, parent)
+    @value = value
+    @parent = parent
+  end
+
+  # ハンドラタイプ名
+  # class_attribute :type, instance_writer: false
+  def type
+    self.class.type
+  end
+
+  # 呼び出し元のオブジェクト
+  def parent
+    @parent&.weakref_alive? ? @parent : nil
+  end
+
+  # valueを定義すれば変更できる
+  # def value()
+  #   self
+  # end
+  #
+  # sourceから値が得られるかチェックし、得られるなら値をセットする
+  # 継承したクラスにて実装する
+  # def match(source)
+  #   PseudoMatchData.new("post_match", {"key" => "value"})
+  # end
+
+  # matchが返すmatch_dataのためのクラス
+  class PseudoMatchData < Hash
+    attr_reader :post_match
+
+    def initialize(post_match, hash)
+      super()
+      @post_match = post_match
+      replace(hash)
+    end
+
+    def names
+      keys.map(&:to_s)
+    end
+  end
+end
+
+class EvalHandler < SiteSettingHandler
+  def match(source)
+    eval(@value, binding, parent&.path || "(nil)") # rubocop:disable Security/Eval
+  end
+  add_handler(path_or_type: "eval")
+end

--- a/webnovel/kakuyomu.jp.yaml
+++ b/webnovel/kakuyomu.jp.yaml
@@ -10,33 +10,87 @@ confirm_over18: no
 append_title_to_folder_name: yes
 title_strip_pattern: null
 sitename: *name
-version: 1.0
+version: 2.0
+
+# ------------------------------------------------------------
+# 前処理設定
+# jsonを処理して正規表現で取得可能なデータへ変換し挿入する
+code: &code
+  eval: |-
+    magicword = "KakuyomuPreprocessEvalMagicWord"
+    # magicwordがある場合、既にこの前処理が行われているので何もしない
+    unless source.include?(magicword)
+      require "json"
+      source.match(%r|<script id="__NEXT_DATA__" type="application/json">(.*)</script>|) do |m|
+        json = JSON.parse($1)
+        # data: 各データが収められたハッシュ
+        data = json["props"]["pageProps"]["__APOLLO_STATE__"]
+        # work: この作品のデータ
+        work = data["Work:#{json["query"]["workId"]}"]
+        # まずTOCを処理する
+        toc = work["tableOfContents"]
+        # workのTOCはTableOfContentsChapterの参照の配列となっているので、それを解決する
+        toc.map! {|v| data[v["__ref"]]}
+        # TableOfContentsChapterにはChapterと各話の配列があるのでそれを取り出し
+        toc.map! {|v| [v["chapter"], v["episodeUnions"]]}
+        # Chapterと各話を一つの配列にフラットにし
+        toc.flatten!
+        # Chapterが使われていない場合にあるnilを排除し
+        toc.compact!
+        # Chapterと各話は参照なので、それを解決し
+        toc.map! {|v| data[v["__ref"]]}
+        # 必要な属性値を取り出して「;」でつないでまとめる
+        # __typename: ChapterかEpisodeかの判別用
+        # level: Chapterにあり1か2かでchapterかsubchapterか判別する
+        # id: Episodeならindex値として必要。Chapterなら必要ないが処理の簡略化のため付加している
+        # publishedAt: Episodeにありsubupdateとして利用する
+        # title: Chapter、Episode共にタイトルとなる
+        # 最後のtitle以外で「;」を含む事は無いはず
+        toc_attr = %w(__typename level id publishedAt title)
+        toc.map! {|v| v.slice(*toc_attr).values.join(";")}
+        # 続いてworkの著者を処理する
+        # 著者の参照から表示用の名前 activityName を取得する
+        work["author"] = data[work["author"]["__ref"]]["activityName"]
+        # alternateAuthorName がある場合は、それも使う。
+        work["author"] = work["alternateAuthorName"] + "／" + work["author"] if work["alternateAuthorName"]
+        # あらすじの改行を<br>に変換し、正規表現を単純化する。<br>はnarourb側で再変換される
+        work["introduction"].gsub!("\n", "<br>")
+        # workからTOC以外に利用する属性を列挙している
+        work_attr = %w(author title serialStatus publicEpisodeCount publishedAt
+            editedAt lastEpisodePublishedAt totalCharacterCount introduction)
+        # HTMLコメントの開始、前処理済みか検知するためのmagicword、
+        # TOC以外のworkの利用する属性値、TOC、HTMLコメントの終了を生成し
+        str = ["<!---", magicword,
+          work.slice(*work_attr).map {|v| v.join("::")},
+          toc, "--->"].join("\n")
+        # 元のページデータに挿入する。デバッグ時用に元々のデータはすべて残す。
+        source.insert(m.begin(0), str)
+        # 元々のデータは基本必要ないのでreplaceを使えば元々のデータはすべて消える。
+        #source.replace(str)
+      end
+    end
+    nil
 
 # ------------------------------------------------------------
 # 書籍情報取得設定
-title: &title |-
-  <h1 id="workTitle"><a href=".+?">(?<title>.+?)</a></h1>
-author: |-
-  (?:<span class="activityName" itemprop="author">(?<author>.+?)</span>)|(?:<span class="screenName.*?">(?<author>.+?)</span>)
-story: &story |-
-  <p id="introduction" class="ui-truncateTextButton js-work-introduction">(?<story>.+?)(?:[\n ]*?</span>|[\n ]*?</p>)
+title: &title
+  - *code
+  - ^title::(?<title>.+?)$
+author:
+  - ^author::(?<author>.+?)$
+story: &story
+  - ^introduction::(?<story>.+?)$
 
 # ------------------------------------------------------------
 # 目次取得設定
 toc_url: \\k<top_url>/works/\\k<ncode>
-subtitles: |-2
-            (?:<li class="widget-toc-chapter widget-toc-level1.*?">
-              <span>(?<chapter>.+?)</span>
-            </li>
-            )?(?:<li class="widget-toc-chapter widget-toc-level2.*?">
-              <span>(?<subchapter>.+?)</span>
-            </li>
-            )?<li class="widget-toc-episode">
-              <a href="(?<href>/works/\d+/episodes/(?<index>\d+))".*?>
-                <span class="widget-toc-episode-titleLabel.*?">(?<subtitle>.+?)</span>
-                <time class="widget-toc-episode-datePublished" datetime="(?<subupdate>.+?)">.+?</time>
-              </a>
-            </li>
+subtitles:
+  - *code
+  - (?x)
+    ^(?:Chapter;1;\d+;(?<chapter>.+?)\n)?
+    (?:Chapter;2;\d+;(?<subchapter>.+?)\n)?
+    Episode;(?<index>\d+);(?<subupdate>.+?);(?<subtitle>.+?)$
+href: /works/\\k<ncode>/episodes/\\k<index>
 
 # ------------------------------------------------------------
 # 本文取得設定
@@ -53,29 +107,28 @@ novel_info_url: \\k<toc_url>
 t: *title
 
 # novel_type 小説種別
-nt: '<dt><span>執筆状況</span></dt>\n *?<dd>(?<novel_type>.+?)</dd>'
+nt: ^serialStatus::(?<novel_type>.+?)$
 novel_type_string:
-  連載中: 1
-  完結済: 3
+  RUNNING: 1
+  COMPLETED: 3
 
 # general_all_no 掲載話数
-ga: '<dt><span>エピソード</span></dt>\n *?<dd>(?<general_all_no>\d+)話</dd>'
+ga: ^publicEpisodeCount::(?<general_all_no>.+?)$
 
 # story あらすじ
 s: *story
 
 # general_firstup 初回掲載日
-gf: '<dt><span>公開日</span></dt>\n *?<dd><time itemprop="datePublished" datetime="(?<general_firstup>.+?)">.+?</time>'
+gf: ^publishedAt::(?<general_firstup>.+?)$
 
-# novelupdated_at 小説の更新時刻。最終掲載日で代用
-nu: '<dt><span>最終更新日</span></dt>\n *?<dd><time itemprop="dateModified" datetime="(?<novelupdated_at>.+?)">.+?</time>'
+# novelupdated_at 小説の更新時刻
+nu: ^editedAt::(?<novelupdated_at>.+?)$
 
 # general_lastup 最新話掲載日
-gl: null
+gl: ^lastEpisodePublishedAt::(?<general_lastup>.+?)$
 
 # writer 作者名
-w: |-
-  (?:<span class="activityName" itemprop="author">(?<writer>.+?)</span>)|(?:<span class="screenName.*?">(?<writer>.+?)</span>)
+w: ^author::(?<writer>.+?)$
 
 # length 文字数
-l: '<dt><span>総文字数</span></dt>\n *?<dd>(?<length>.+?)文字</dd>'
+l: ^totalCharacterCount::(?<length>.+?)$


### PR DESCRIPTION
方法的には良いとは言えないですが、サイト設定のファイルにrubyのコードが書けるように拡張し、それによってカクヨム対応のコードを埋め込み対応しています。
方法としては従来、正規表現であった所に、ハッシュで他の機能を設定できるようにしました。
現在はevalのみ実装。必要であれば機能を追加できます。
- 従来
```yaml
title: 正規表現
```
- 拡張後
```yaml
title:
  eval: Rubyコード
```
本当は掲示板でもありましたが、サイト固有の処理が外出し出来ると良いので、将来的にはそっちで出来ればと思います。
