### PR TITLE
なろうルビタグの変換バグを修正

### DIFF
--- a/lib/converterbase.rb
+++ b/lib/converterbase.rb
@@ -939,8 +939,8 @@ class ConverterBase
       "#{m1[0...-1]}#{openclose_symbols[0]}#{m2}#{openclose_symbols[1]}"
     when is_sesame?(m1, m2, last_char)
       sesame(m1)
-    when m1.include?("｜")
-      "#{m1.sub(/｜([^｜]*)$/, "［＃ルビ用縦線］\\1")}《#{ruby_youon_to_big(m2)}》"
+    when m1 =~ /^(.*)｜([^｜≪≫（）《》]+)$/
+      "#{$1}［＃ルビ用縦線］#{$2}《#{ruby_youon_to_big(m2)}》"
     when object_of_ruby?(last_char)
       if openclose_symbols[0] == "≪" && m2 !~ /^#{AUTO_RUBY_CHARACTERS}$/
         # 《 》タイプのルビであっても、｜が存在しない場合の自動ルビ化対象はひらがな等だけである


### PR DESCRIPTION
「小説家になろう」のルビタグ｜（）≪≫が混在する場合の変換ミスを修正しました。
現行だと

```
入力: "｜朝（あさ）と夜≪よる≫"

出力: "｜｜朝《あさ》と夜《よる》"
```

となるのを

`出力: "｜朝《あさ》と｜夜《よる》"`

となるように直しました。

[ルビの（　）と《　》が同一行に混じってかつ｜があると正しく処理されない\#155](https://github.com/whiteleaf7/narou/issues/155)
に対応したつもりです。
確認のため、簡単なテストコードを作成しました。
参考までに貼り付けさせて頂きます。
[test_narou_ruby.zip](https://github.com/whiteleaf7/narou/files/14298801/test_narou_ruby.zip)
