### PR TITLE
電書協最小対応版

### DIFF
--- a/lib/aozora.rb
+++ b/lib/aozora.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+#
+# Copyright 2013 whiteleaf. All rights reserved.
+#
+
+require "memoist"
+require "pathname"
+require "active_support/core_ext/hash/deep_merge"
+require_relative "narou"
+
+module AozoraEpub3
+  _ORG = {
+    type: :org,
+    name: "AozoraEpub3 (元祖)",
+    exist: "template/OPS/css/vertical_font.css",
+    dakuten: [:css, :font],
+    css: {
+      mode: :erb,
+      src: "vertical_font.css",
+      dst: "template/OPS/css_custom/vertical_font.css",
+    },
+    font: {
+      mode: :copy,
+      src: "DMincho.ttf",
+      dst: "template/OPS/fonts/DMincho.ttf",
+    },
+  }
+  _DEN = _ORG.deep_merge({  # hash#deep_merge <- active_support
+    type: :den,
+    name: "AozoraEpub3 (電書協)",
+    exist: "template/item/style/font.css",
+    css: {
+      src: "denshokyo_font.css",
+      dst: "template/item/style_custom/font.css",
+    },
+    font: { dst: "template/item/fonts/DMincho.ttf" },
+  })
+  AOZORAEPUB3_TYPE = [_ORG, _DEN]
+
+  class << self
+    extend Memoist
+
+    def aozoraepub3_type
+      aozoraepub3_type_with_path(Narou.aozoraepub3_path.dirname)
+    end
+    memoize :aozoraepub3_type
+
+    # ファイル配置がオリジナルタイプか電書協タイプか判定する
+    def aozoraepub3_type_with_path(aozora_path)
+      AOZORAEPUB3_TYPE.find do |item|
+        aozora_path.join(item[:exist]).exist?
+      end
+    end
+
+  end
+end

--- a/lib/command/init.rb
+++ b/lib/command/init.rb
@@ -6,6 +6,7 @@
 
 require_relative "../inventory"
 require_relative "../commandbase"
+require_relative "../aozora"
 
 module Command
   class Init < CommandBase
@@ -127,8 +128,10 @@ module Command
       puts chuki_tag_path
       puts
       # ファイルコピー
-      src = ["AozoraEpub3.ini", "vertical_font.css"]
-      dst = ["AozoraEpub3.ini", "template/OPS/css_custom/vertical_font.css"]
+      type = AozoraEpub3.aozoraepub3_type_with_path(Pathname(aozora_path))
+      src = ["AozoraEpub3.ini", type[:css][:src]]
+      dst = ["AozoraEpub3.ini", type[:css][:dst]]
+      use_dakuten_font = false
       puts "(次のファイルをコピーor上書きしました)"
       src.size.times do |i|
         src_full_path = File.join(Narou.preset_dir, src[i])

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -376,6 +376,7 @@ module Helper
   def erb_copy(src, dst, _binding)
     data = File.read(src, mode: "r:BOM|UTF-8")
     result = ERB.new(data, trim_mode: "-").result(_binding)
+    Pathname(dst).dirname.mkpath
     File.write(dst, result)
   end
 

--- a/lib/novelconverter.rb
+++ b/lib/novelconverter.rb
@@ -17,6 +17,7 @@ require_relative "helper"
 require_relative "inventory"
 require_relative "html"
 require_relative "eventable"
+require_relative "aozora"
 
 class NovelConverter
   include Narou::Eventable
@@ -85,22 +86,20 @@ class NovelConverter
     }
   end
 
-  DAKUTEN_FROM = ["vertical_font_with_dakuten.css", "DMincho.ttf"]
-  DAKUTEN_TO = ["template/OPS/css_custom/vertical_font.css", "template/OPS/fonts/DMincho.ttf"]
-  DAKUTEN_ERB = [true, false]
-
   def self.activate_dakuten_font_files
     preset_dir = Narou.preset_dir
-    aozora_dir = File.dirname(Narou.aozoraepub3_path)
+    aozora_dir = Narou.aozoraepub3_path.dirname
+    type = AozoraEpub3.aozoraepub3_type
     line_height = Narou.line_height
+    use_dakuten_font = true
 
-    DAKUTEN_FROM.each_with_index do |name, i|
-      src = File.join(preset_dir, name)
-      dst = File.join(aozora_dir, DAKUTEN_TO[i])
-      if DAKUTEN_ERB[i]
+    type[:dakuten].each do |name|
+      src = preset_dir.join(type[name][:src])
+      dst = aozora_dir.join(type[name][:dst])
+      if type[name][:mode] == :erb
         Helper.erb_copy(src, dst, binding)
       else
-        FileUtils.mkdir_p(File.dirname(dst))
+        dst.dirname.mkpath
         FileUtils.copy(src, dst)
       end
     end
@@ -108,12 +107,14 @@ class NovelConverter
 
   def self.inactivate_dakuten_font_files
     preset_dir = Narou.preset_dir
-    aozora_dir = File.dirname(Narou.aozoraepub3_path)
-    path_normal_vertical_css = File.join(preset_dir, "vertical_font.css")
+    aozora_dir = Narou.aozoraepub3_path.dirname
+    type = AozoraEpub3.aozoraepub3_type
+    path_normal_css = preset_dir.join(type[:css][:src])
     line_height = Narou.line_height
+    use_dakuten_font = false
 
-    Helper.erb_copy(path_normal_vertical_css, File.join(aozora_dir, DAKUTEN_TO[0]), binding)
-    FileUtils.remove(File.join(aozora_dir, DAKUTEN_TO[1]))
+    Helper.erb_copy(path_normal_css, aozora_dir.join(type[:css][:dst]), binding)
+    aozora_dir.join(type[:font][:dst]).delete
   end
 
   #

--- a/preset/denshokyo_font.css
+++ b/preset/denshokyo_font.css
@@ -1,22 +1,18 @@
 @charset "utf-8";
 @namespace "http://www.w3.org/1999/xhtml";
 
-body {
+.vrtl body, .hltr body {
 	font-family: "@ＭＳ 明朝", "@MS Mincho", "ヒラギノ明朝 ProN W3", "HiraMinProN-W3", serif, sans-serif;
 	line-height: <%= line_height %>em !important;
 }
 
-.gtc, .b {
+.vrtl .gtc, .hltr .gtc, .b {
 	font-family: '@ＭＳ ゴシック','@MS Gothic',sans-serif !important;
 }
 
-.b { font-weight: bold; }
-.i { font-style: italic; }
-
-rt { font-size: 0.6em; }
+.vrtl rt, .hltr rt { font-size: 0.6em; }
 
 /* カスタム注記用 */
-
 /* 柱（もどき） */
 .running_head {
 	position: absolute !important;
@@ -24,17 +20,32 @@ rt { font-size: 0.6em; }
 	left: 10px;
 	font-size: 0.8em;
 }
-
+<% if tategaki %>
+/* ページ左右中央 調整 */
+.main.block-align-center div.mt3 {
+	margin-left: 0 !important;
+	margin-right: 0 !important;
+}
+.main.block-align-center > div {
+	margin-top: 4em !important;
+}
+div.main.block-align-center div.running_head {
+	position: absolute !important;
+	top: 2em;
+	left: 10px;
+	font-size: 0.8em;
+}
+<% end %>
+<% if use_dakuten_font %>
 /* 濁点フォント */
 @font-face {
 	font-family: "DakutenAokinMincho";
 	src: url(../fonts/DMincho.ttf) format("truetype");
 }
-
-.dakuten {
+.vrtl .dakuten, .hltr .dakuten {
 	font-family: "DakutenAokinMincho" !important;
 }
-
+<% end %>
 /* 二分アキ */
 .half_em_space { padding-top: 0.5em; }
 
@@ -52,15 +63,15 @@ rt { font-size: 0.6em; }
 	box-shadow: 3px 3px 3px #bbb;
 	-webkit-box-shadow: 3px 3px 3px #bbb;
 }
-.jzm .custom_parameter_block {
+.vrtl .jzm .custom_parameter_block, .hltr .jzm .custom_parameter_block {
 	display: block;
 }
-.jzm .p .custom_parameter_block {
+.vrtl .jzm .p .custom_parameter_block, .hltr .jzm .p .custom_parameter_block {
 	display: inline-block;
 }
 
 /* 前書き */
-.introduction {
+.vrtl .introduction {
 	float: right;
 	font-size: 83%;
 	line-height: 1.5em !important;
@@ -74,15 +85,15 @@ rt { font-size: 0.6em; }
 	text-align: left !important;
 	height: 70%;
 }
-.jzm .introduction {
+.vrtl .jzm .introduction, .hltr .jzm .introduction {
 	display: block;
 }
-.jzm .p .introduction {
+.vrtl .jzm .p .introduction, .hltr .jzm .p .introduction {
 	display: inline-block;
 }
 
 /* 後書き */
-.postscript {
+.vrtl .postscript {
 	float: right;
 	font-size: 83%;
 	line-height: 1.5em !important;
@@ -96,13 +107,13 @@ rt { font-size: 0.6em; }
 	text-align: left !important;
 	height: 70%;
 }
-.jzm .postscript {
+.vrtl .jzm .postscript, .hltr .jzm .postscript {
 	display: block;
 }
-.jzm .p .postscript {
+.vrtl .jzm .p .postscript, .hltr .jzm .p .postscript {
 	display: inline-block;
 }
 
-div.clear {
+.vrtl div.clear, .hltr div.clear {
 	clear: both;
 }

--- a/preset/denshokyo_font.css
+++ b/preset/denshokyo_font.css
@@ -1,55 +1,68 @@
 @charset "utf-8";
 @namespace "http://www.w3.org/1999/xhtml";
 
-.vrtl body, .hltr body {
+/** 横書きフォント */
+.hltr body {
+	font-family: "ＭＳ 明朝", "MS Mincho", "ヒラギノ明朝 ProN W3", "HiraMinProN-W3", serif, sans-serif;
+}
+/** 縦書きフォント */
+.vrtl body {
 	font-family: "@ＭＳ 明朝", "@MS Mincho", "ヒラギノ明朝 ProN W3", "HiraMinProN-W3", serif, sans-serif;
+}
+
+/** 以下 narou.rb オリジナル設定 */
+
+body {
 	line-height: <%= line_height %>em !important;
 }
 
-.vrtl .gtc, .hltr .gtc, .b {
+/* .gtc .b .i は電書協準拠により .gfont .bold .italic となる */
+/* AozoraEpub3には太字注記でゴシックを使うオプション(BoldUseGothic)あるが.bに設定している */
+.vrtl .bold {
 	font-family: '@ＭＳ ゴシック','@MS Gothic',sans-serif !important;
 }
 
-.vrtl rt, .hltr rt { font-size: 0.6em; }
+/* .bold と .italic の設定は標準で成されている気がするけど */
+.b { font-weight: bold; }
+.i { font-style: italic; }
+
+rt { font-size: 0.6em; }
 
 /* カスタム注記用 */
+
 /* 柱（もどき） */
+/* 柱（もどき）は横書きされるので切替えは必要なさそう */
 .running_head {
 	position: absolute !important;
 	top: 15px;
 	left: 10px;
 	font-size: 0.8em;
 }
-<% if tategaki %>
+
 /* ページ左右中央 調整 */
-.main.block-align-center div.mt3 {
-	margin-left: 0 !important;
-	margin-right: 0 !important;
+/* ページ左右中央では html.hltr なので横書きの３字下げも付くのを防ぐ */
+.main.vrtl.block-align-center div.mt3 {
+	margin-left: 0;
 }
-.main.block-align-center > div {
-	margin-top: 4em !important;
-}
-div.main.block-align-center div.running_head {
-	position: absolute !important;
-	top: 2em;
-	left: 10px;
-	font-size: 0.8em;
-}
-<% end %>
+
 <% if use_dakuten_font %>
 /* 濁点フォント */
 @font-face {
 	font-family: "DakutenAokinMincho";
 	src: url(../fonts/DMincho.ttf) format("truetype");
 }
-.vrtl .dakuten, .hltr .dakuten {
+
+/* 横書きでは設定の有無に関わらず濁点は付かない。narou.rbで縦書きに限定すべき？ */
+.dakuten {
 	font-family: "DakutenAokinMincho" !important;
 }
+
 <% end %>
 /* 二分アキ */
-.half_em_space { padding-top: 0.5em; }
+.vrtl .half_em_space { padding-top: 0.5em; }
 
 /* パラメーター（折り返しあり） */
+/* margin, padding の設定あるが許容範囲？ */
 .custom_parameter_block {
 	font-size: 100%;
 	line-height: 1.2em !important;
@@ -63,14 +76,15 @@ div.main.block-align-center div.running_head {
 	box-shadow: 3px 3px 3px #bbb;
 	-webkit-box-shadow: 3px 3px 3px #bbb;
 }
-.vrtl .jzm .custom_parameter_block, .hltr .jzm .custom_parameter_block {
+.jzm .custom_parameter_block {
 	display: block;
 }
-.vrtl .jzm .p .custom_parameter_block, .hltr .jzm .p .custom_parameter_block {
+.jzm .p .custom_parameter_block {
 	display: inline-block;
 }
 
 /* 前書き */
+/* height の設定あるので縦書き限定 */
 .vrtl .introduction {
 	float: right;
 	font-size: 83%;
@@ -85,14 +99,15 @@ div.main.block-align-center div.running_head {
 	text-align: left !important;
 	height: 70%;
 }
-.vrtl .jzm .introduction, .hltr .jzm .introduction {
+.jzm .introduction {
 	display: block;
 }
-.vrtl .jzm .p .introduction, .hltr .jzm .p .introduction {
+.jzm .p .introduction {
 	display: inline-block;
 }
 
 /* 後書き */
+/* height の設定あるので縦書き限定 */
 .vrtl .postscript {
 	float: right;
 	font-size: 83%;
@@ -107,13 +122,16 @@ div.main.block-align-center div.running_head {
 	text-align: left !important;
 	height: 70%;
 }
-.vrtl .jzm .postscript, .hltr .jzm .postscript {
+.jzm .postscript {
 	display: block;
 }
-.vrtl .jzm .p .postscript, .hltr .jzm .p .postscript {
+.jzm .p .postscript {
 	display: inline-block;
 }
 
-.vrtl div.clear, .hltr div.clear {
+/* .hltr .vrtl 無指定でも問題ないと思う */
+div.clear {
 	clear: both;
 }
+
+/* 字詰め (.jzm) 設定はよく分からない */

--- a/preset/vertical_font.css
+++ b/preset/vertical_font.css
@@ -24,7 +24,17 @@ rt { font-size: 0.6em; }
 	left: 10px;
 	font-size: 0.8em;
 }
+<% if use_dakuten_font %>
+/* 濁点フォント */
+@font-face {
+	font-family: "DakutenAokinMincho";
+	src: url(../fonts/DMincho.ttf) format("truetype");
+}
 
+.dakuten {
+	font-family: "DakutenAokinMincho" !important;
+}
+<% end %>
 /* 二分アキ */
 .half_em_space { padding-top: 0.5em; }
 


### PR DESCRIPTION
処理の流れは基本的に従来と同じですが、AozoraEpub3のタイプ（テンプレートがオリジナルか電協準拠か）により選択されたデータセットを使う事で両対応しています。
#419 も参照

- aozora.rb
  - 現状はタイプ判定の関係のみだが、将来的にAozoraEpub3とkindlegen関係をまとめたい
- AozoraEpub3.:aozoraepub3_type. AozoraEpub3.:aozoraepub3_type_with_path
  - AozoraEpub3のタイプを判別して必要なデータセットをハッシュで返す
  - 現状はタイプ、名前、タイプを判定するためのファイル、CSSファイル、fontファイルからなる
- 濁点フォン関係で切替えていたCSSファイルを一つに統合
  - https://github.com/whiteleaf7/narou/pull/420 での案を採用した
- 変更部分は pathname を使用した
  - AozoraEpub3.:aozoraepub3_type_with_pathの引数は pathname 前提

追加した AozoraEpub3 と直接的な変更の Command::Init, NovelConverter 以外で Helper.erb_copy を修正している