### PR TITLE
Replace Erubis by Erubi

### DIFF
--- a/lib/web/appserver.rb
+++ b/lib/web/appserver.rb
@@ -12,7 +12,7 @@ require "sinatra/base"
 require "sinatra/json"
 require "sinatra/reloader" if $development
 # require "better_errors" if $debug
-require "tilt/erubis"
+require "tilt/erubi"
 require "tilt/haml"
 require "tilt/sass"
 require_relative "../commandline"

--- a/narou.gemspec
+++ b/narou.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'haml', '>= 5.1.2', '< 6'
   gem.add_runtime_dependency 'memoist', '~> 0.11.0'
   gem.add_runtime_dependency 'systemu', '~> 2.6', '>= 2.6.5'
-  gem.add_runtime_dependency 'erubis', '~> 2.7'
+  gem.add_runtime_dependency 'erubi', '~> 1.13'
   gem.add_runtime_dependency 'open_uri_redirections', '~> 0.2', '>= 0.2.1'
   gem.add_runtime_dependency 'activesupport', '>= 6.1', '< 8.0'
   gem.add_runtime_dependency 'unicode-display_width', '~> 1.4'


### PR DESCRIPTION
tiltがerubisのサポートを外した件の対処で、erubiに置き換えました。
とりあえず起動程度しか確認していませんが互換っぽいのでPRしておきます。
close #443