### PR TITLE
260728までの各小説サイト修正まとめ

### DIFF
--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -983,8 +983,8 @@ class Downloader
       subtitles << {
         "index" => @setting["index"],
         "href" => @setting["href"],
-        "chapter" => @setting["chapter"].to_s,
-        "subchapter" => @setting["subchapter"].to_s,
+        "chapter" => slim_subtitle(@setting["chapter"]).to_s,
+        "subchapter" => slim_subtitle(@setting["subchapter"]).to_s,
         "subtitle" => slim_subtitle(@setting["subtitle"]),
         "file_subtitle" => title_to_filename(@setting["subtitle"]),
         "subdate" => subdate,

--- a/webnovel/h.syosetu.org.yaml
+++ b/webnovel/h.syosetu.org.yaml
@@ -1,0 +1,81 @@
+# ------------------------------------------------------------
+# 小説サイト定義
+name: &name ハーメルンR18
+domain: h.syosetu.org
+top_url: https?://\\k<domain>
+url:
+  - \\k<top_url>/novel/(?<ncode>\d+)
+  - https?://h.syosetu.org/(?<ncode>\d+)
+encoding: UTF-8
+confirm_over18: no
+append_title_to_folder_name: yes
+title_strip_pattern: null
+cookie: over18=off
+sitename: ハーメルン
+version: 1.3
+
+# ------------------------------------------------------------
+# 目次取得設定
+toc_url: https://h.syosetu.org/novel/\\k<ncode>/
+subtitles: |-
+  (?:<li class="episode-list__chapter">\s*<div class="episode-list__chapter-title">(?<chapter>.+?)</div>\s*</li>\s*
+  )?\s*<li class="episode-list__item.*?">
+  \s*<a href="./(?<index>\d+?).html" class="episode-list__link">
+  \s*<span class="episode-list__mark.*?">.*?</span>
+  \s*<span class="episode-list__title.*?" >(?<subtitle>.+?)</span>
+  \s*<time class="episode-list__date".*?>(?<subdate>.+?)</time>
+  \s*<span class="episode-list__revision"(?: title="(?<subupdate>.+?)改稿")?>.*?</span>\s*</a>\s*</li>
+
+href: \\k<index>.html
+
+error_message: 投稿者が削除、もしくは間違ったアドレスを指定しています|この作品は投稿者によって削除されました|この作品は完全非公開設定です|この小説は非公開設定になっています
+
+# ------------------------------------------------------------
+# 本文取得設定
+
+body_pattern: |-
+  <span style="font-size:120%">.+?</span><BR><BR>
+  (?<body>.+?)
+  (?:<div id="atogaki"><br><hr><br>(?<postscript>.+?)</div>)?
+
+introduction_pattern: <div id="maegaki">(?<introduction>.+)<br><hr><br></div><
+postscript_pattern: null
+
+illust_current_url: null
+illust_grep_pattern: <a href="(?<src>.+?)" alt="挿絵" name='img'>【挿絵表示】</a>
+
+# ------------------------------------------------------------
+# 小説情報からパースするための設定
+novel_info_url: https://h.syosetu.org/?mode=ss_detail&nid=\\k<ncode>
+
+# タイトル
+t: タイトル</td><td.*?><a href=.+?>(?<title>.+?)</a>
+
+# novel_type 小説種別
+nt: 話数</td><td.*?>(?<novel_type>.+?) .+?話</td>
+novel_type_string:
+  連載(連載中): 1
+  連載(未完): 1
+  連載(完結): 3
+  短編: 2
+
+# general_all_no 掲載話数
+ga: 話数</td><td.*?>.+? (?<general_all_no>\d+)話</td>
+
+# story あらすじ
+s: "あらすじ</td><td.*?>(?<story>.+?)</td>"
+
+# general_firstup 初回掲載日
+gf: 掲載開始</td><td.*?>(?<general_firstup>.+?)</td>
+
+# novelupdated_at 小説の更新時刻
+nu: null
+
+# general_lastup 最終掲載日
+gl: 最新投稿</td><td.*?>(?<general_lastup>.+?)</td>
+
+# writer 作者名
+w: 作者</td><td.*?>(?:<a href=.+?>)?(?<writer>.+?)(?:</a>)?</td>
+
+# length 文字数
+l: 合計文字数</td><td.*?>(?<length>.+?)文字

--- a/webnovel/kakuyomu.jp.yaml
+++ b/webnovel/kakuyomu.jp.yaml
@@ -10,7 +10,7 @@ confirm_over18: no
 append_title_to_folder_name: yes
 title_strip_pattern: null
 sitename: *name
-version: 2.0
+version: 2.1
 
 # ------------------------------------------------------------
 # 前処理設定
@@ -28,7 +28,7 @@ code: &code
         # work: この作品のデータ
         work = data["Work:#{json["query"]["workId"]}"]
         # まずTOCを処理する
-        toc = work["tableOfContents"]
+        toc = work["tableOfContentsV2"]
         # workのTOCはTableOfContentsChapterの参照の配列となっているので、それを解決する
         toc.map! {|v| data[v["__ref"]]}
         # TableOfContentsChapterにはChapterと各話の配列があるのでそれを取り出し

--- a/webnovel/ncode.syosetu.com.yaml
+++ b/webnovel/ncode.syosetu.com.yaml
@@ -10,24 +10,20 @@ append_title_to_folder_name: yes
 title_strip_pattern: null
 cookie: over18=yes
 sitename: *name
-version: 2.0
+version: 2.3
 
 # ------------------------------------------------------------
 # 目次取得設定
 toc_url: https://\\k<domain>/\\k<ncode>/
 subtitles: |-
-  (?:<div class="p-eplist__chapter-title">(?<chapter>.+?)</div>
-  
+  (?:<div class="p-eplist__chapter-title">(?<chapter>.+?)</div>\s*
   )?<div class="p-eplist__sublist">
   <a href="(?<href>/.+?/(?<index>\d+?)/)" class="p-eplist__subtitle">
-  (?<subtitle>.+?)
-  </a>
-  
+  (?<subtitle>.+?)\s*</a>\s*
   <div class="p-eplist__update">
   (?:<span class="p-eplist__favep">.+?</span></span>)?(?<subdate>.+?)
-  (?:<span title="(?<subupdate>.+?) 改稿">（<u>改</u>）</span>
-  )?</div>
-  </div>
+  (?:<span title="(?<subupdate>.+?) 改稿">（<u>改</u>）</span>\s*)?</div>\s*</div>
+
 next_toc: <a href="/(?<next_page>[^"]+)" class="c-pager__item c-pager__item--next">
 next_url: https://\\k<domain>/\\k<next_page>
 # 最大のページ数を得る。固定の数字でも可。
@@ -61,44 +57,44 @@ narou_api_url: https://api.syosetu.com/novelapi/api/
 novel_info_url: \\k<top_url>/novelview/infotop/ncode/\\k<ncode>/
 
 # タイトル
-t: <h1><a href=".+?">(?<title>.+?)</a></h1>
+t: <h1 class="p-infotop-title">\s<a href=".+?">(?<title>.+?)</a>\s</h1>
 
 # novel_type 小説種別
-nt: <span id="noveltype(?:.*?)">(?<novel_type>.+?)</span>
+nt: <span class="p-infotop-type__type(?:.*?)">(?<novel_type>.+?)</span>
 novel_type_string:
   連載中: 1
   完結済: 3
   短編: 2
 
 # general_all_no 掲載話数
-ga: </span>全(?<general_all_no>\d+)エピソード
+ga: <span class="p-infotop-type__allep">全(?<general_all_no>\d+)エピソード
 
 # story あらすじ
-s: <td class="ex">(?<story>.+?)</td>
+s: <dt class="p-infotop-data__title">あらすじ</dt>\s<dd class="p-infotop-data__value">(?<story>.+?)</dd>
 
 # general_firstup 初回掲載日
 gf: |-
-  <th>掲載日</th>
-  <td>(?<general_firstup>.+?)</td>
+  <dt class="p-infotop-data__title">掲載日</dt>
+  <dd class="p-infotop-data__value">(?<general_firstup>.+?)</dd>
 
 # novelupdated_at 小説の更新時刻。連載小説だと書いてないので最終掲載日で代用
 nu: |-
-  <th>(?:最終更新日|最新掲載日|最終掲載日)</th>
-  <td>(?:
+  <dt class="p-infotop-data__title">(?:最終更新日|最新掲載日|最終掲載日)</dt>
+  <dd class="p-infotop-data__value">(?:
   )?(?<novelupdated_at>.+?)(?:
-  )?</td>
+  )?</dd>
 
 # general_lastup 最終掲載日
 gl: |-
-  <th>(?:最新掲載日|最終掲載日)</th>
-  <td>(?<general_lastup>.+?)</td>
+  <dt class="p-infotop-data__title">(?:最新掲載日|最終掲載日)</dt>
+  <dd class="p-infotop-data__value">(?<general_lastup>.+?)</dd>
 
 # writer 作者名
 w: |-
-  <th>作者名</th>
-  <td>(?:<a href=".+?">)?(?<writer>.+?)(?:</a>)?.?</td>
+  <dt class="p-infotop-data__title">作者名</dt>
+  <dd class="p-infotop-data__value">(?:<a href=".+?">)?(?<writer>.+?)(?:</a>)?.?</dd>
 
 # length 文字数
 l: |-
-  <th>文字数</th>
-  <td>(?<length>.+?)文字</td>
+  <dt class="p-infotop-data__title">文字数</dt>
+  <dd class="p-infotop-data__value">(?<length>.+?)文字</dd>

--- a/webnovel/novel18.syosetu.com.yaml
+++ b/webnovel/novel18.syosetu.com.yaml
@@ -12,27 +12,23 @@ cookie: over18=yes
 
 # 掲載サイト名は動的に取得する
 sitename: |-
-  <th>掲載サイト</th>
-  <td>(?<sitename>.+?)\(.+\)</td>
+  <dt class="p-infotop-data__title">掲載サイト</dt>
+  <dd class="p-infotop-data__value">(?<sitename>.+?)\(.+\)</dd>
 
-version: 2.0
+version: 2.3
 
 # ------------------------------------------------------------
 # 目次取得設定
 toc_url: https://\\k<domain>/\\k<ncode>/
 subtitles: |-
-  (?:<div class="p-eplist__chapter-title">(?<chapter>.+?)</div>
-  
+  (?:<div class="p-eplist__chapter-title">(?<chapter>.+?)</div>\s*
   )?<div class="p-eplist__sublist">
   <a href="(?<href>/.+?/(?<index>\d+?)/)" class="p-eplist__subtitle">
-  (?<subtitle>.+?)
-  </a>
-  
+  (?<subtitle>.+?)\s*</a>\s*
   <div class="p-eplist__update">
   (?:<span class="p-eplist__favep">.+?</span></span>)?(?<subdate>.+?)
-  (?:<span title="(?<subupdate>.+?) 改稿">（<u>改</u>）</span>
-  )?</div>
-  </div>
+  (?:<span title="(?<subupdate>.+?) 改稿">（<u>改</u>）</span>\s*)?</div>\s*</div>
+
 next_toc: <a href="/(?<next_page>[^"]+)" class="c-pager__item c-pager__item--next">
 next_url: https://\\k<domain>/\\k<next_page>
 # 最大のページ数を得る。固定の数字でも可。
@@ -66,44 +62,44 @@ narou_api_url: https://api.syosetu.com/novel18api/api/
 novel_info_url: \\k<top_url>/novelview/infotop/ncode/\\k<ncode>/
 
 # タイトル
-t: <h1><a href=".+?">(?<title>.+?)</a></h1>
+t: <h1 class="p-infotop-title">\s<a href=".+?">(?<title>.+?)</a>\s</h1>
 
 # novel_type 小説種別
-nt: <span id="noveltype(?:.*?)">(?<novel_type>.+?)</span>
+nt: <span class="p-infotop-type__type(?:.*?)">(?<novel_type>.+?)</span>
 novel_type_string:
   連載中: 1
   完結済: 3
   短編: 2
 
 # general_all_no 掲載話数
-ga: </span>全(?<general_all_no>\d+)エピソード
+ga: <span class="p-infotop-type__allep">全(?<general_all_no>\d+)エピソード
 
 # story あらすじ
-s: <td class="ex">(?<story>.+?)</td>
+s: <dt class="p-infotop-data__title">あらすじ</dt>\s<dd class="p-infotop-data__value">(?<story>.+?)</dd>
 
 # general_firstup 初回掲載日
 gf: |-
-  <th>掲載日</th>
-  <td>(?<general_firstup>.+?)</td>
+  <dt class="p-infotop-data__title">掲載日</dt>
+  <dd class="p-infotop-data__value">(?<general_firstup>.+?)</dd>
 
 # novelupdated_at 小説の更新時刻。連載小説だと書いてないので最終掲載日で代用
 nu: |-
-  <th>(?:最終更新日|最新掲載日|最終掲載日)</th>
-  <td>(?:
+  <dt class="p-infotop-data__title">(?:最終更新日|最新掲載日|最終掲載日)</dt>
+  <dd class="p-infotop-data__value">(?:
   )?(?<novelupdated_at>.+?)(?:
-  )?</td>
+  )?</dd>
 
 # general_lastup 最終掲載日
 gl: |-
-  <th>(?:最新掲載日|最終掲載日)</th>
-  <td>(?<general_lastup>.+?)</td>
+  <dt class="p-infotop-data__title">(?:最新掲載日|最終掲載日)</dt>
+  <dd class="p-infotop-data__value">(?<general_lastup>.+?)</dd>
 
 # writer 作者名
 w: |-
-  <th>作者名</th>
-  <td>(?:<a href=".+?">)?(?<writer>.+?)(?:</a>)?.?</td>
+  <dt class="p-infotop-data__title">作者名</dt>
+  <dd class="p-infotop-data__value">(?:<a href=".+?">)?(?<writer>.+?)(?:</a>)?.?</dd>
 
 # length 文字数
 l: |-
-  <th>文字数</th>
-  <td>(?<length>.+?)文字</td>
+  <dt class="p-infotop-data__title">文字数</dt>
+  <dd class="p-infotop-data__value">(?<length>.+?)文字</dd>

--- a/webnovel/syosetu.org.yaml
+++ b/webnovel/syosetu.org.yaml
@@ -12,13 +12,19 @@ append_title_to_folder_name: yes
 title_strip_pattern: null
 cookie: over18=off
 sitename: *name
-version: 1.0
+version: 1.3
 
 # ------------------------------------------------------------
 # 目次取得設定
 toc_url: https://syosetu.org/novel/\\k<ncode>/
 subtitles: |-
-  (?:<tr><td colspan=2><strong>(?<chapter>.+?)</strong></td></tr>)?<tr bgcolor="#.+?" class="bgcolor\d"><td width=60%><span id="(?<index>\d+?)">　</span> <a href=.+? style="text-decoration:none;">(?<subtitle>.+?)</a></td><td><NOBR>(?<subdate>.+?)(?:<span title="(?<subupdate>.+?)改稿">\(<u>改</u>\)</span>)?</NOBR></td></tr>
+  (?:<li class="episode-list__chapter">\s*<div class="episode-list__chapter-title">(?<chapter>.+?)</div>\s*</li>\s*
+  )?\s*<li class="episode-list__item.*?">
+  \s*<a href="./(?<index>\d+?).html" class="episode-list__link">
+  \s*<span class="episode-list__mark.*?">.*?</span>
+  \s*<span class="episode-list__title.*?" >(?<subtitle>.+?)</span>
+  \s*<time class="episode-list__date".*?>(?<subdate>.+?)</time>
+  \s*<span class="episode-list__revision"(?: title="(?<subupdate>.+?)改稿")?>.*?</span>\s*</a>\s*</li>
 
 href: \\k<index>.html
 

--- a/webnovel/www.akatsuki-novels.com.yaml
+++ b/webnovel/www.akatsuki-novels.com.yaml
@@ -10,7 +10,7 @@ append_title_to_folder_name: yes
 title_strip_pattern: null
 cookie: CakeCookie[ALLOWED_ADULT_NOVEL]=on
 sitename: *name
-version: 1.0
+version: 1.1
 
 # ------------------------------------------------------------
 # 書籍情報取得設定
@@ -24,6 +24,11 @@ story: |-
 toc_url: \\k<top_url>/stories/index/novel_id~\\k<ncode>
 subtitles: |-
   (?:<tr><td style="border: 0; padding: 0;word-break:break-all;" colspan=\\"2\\"><b>(?<chapter>.+?)</b></td></tr>)*<tr><td>(  )?<a href="(?<href>/stories/view/(?<index>\d+)/novel_id\~\d+)">(?<subtitle>.+?)</a> </td><td class="font-s">(?<subupdate>.+?) </td></tr>
+
+next_toc: <span class="next"><a href="/(?<next_page>[^"]+)" rel="next">
+next_url: https://\\k<domain>/\\k<next_page>
+# 最大のページ数を得る。固定の数字でも可。
+toc_page_max: <span class="table_of_contents"><a href="/stories/index/page~(?<toc_page_max>\d+)/novel_id~\\k<ncode>" rel="table_of_contents">
 
 # subdate(初投稿日)がない場合、一番最初のsubupdateで代用する
 subdate: no


### PR DESCRIPTION
ハーメルン / R18
  目次取得修正
  R18ドメイン対応
  ルビ有り章タイトル対応
    全体(downloader.rb)の chapter subchapter に slim_subtitle 処理を適用
  https://jbbs.shitaraba.net/bbs/read.cgi/computer/44668/1716423212/649-658
カクヨム
  目次取得修正
  https://jbbs.shitaraba.net/bbs/read.cgi/computer/44668/1716423212/575-576
小説家になろう / R18系
  作品情報取得修正
  ノクターン/ムーンライト/ミッドナイトノベルズ 掲載サイト名対応
  https://jbbs.shitaraba.net/bbs/read.cgi/computer/44668/1716423212/209-227
暁
  目次取得 ページネーション対応
  https://jbbs.shitaraba.net/bbs/read.cgi/computer/44668/1511247318/212-213
